### PR TITLE
Test CommonSparseMatrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,38 +25,19 @@ include(DuneMacros)
 find_package(dune-xt-common REQUIRED)
 list(APPEND CMAKE_MODULE_PATH
      "${dune-xt-common_MODULE_PATH}")
-include(DuneUtils)
 
 # start a dune project with information from dune.module
 dune_project()
 dune_enable_all_packages(INCLUDE_DIRS ${dune-xt-la_SOURCE_DIR}/dune
-                         MODULE_LIBRARIES dunextla
-                         VERBOSE)
+                         MODULE_LIBRARIES dunextla)
 
-
-# add header of this module for header listing
-file(GLOB_RECURSE xtlaheader "${CMAKE_CURRENT_SOURCE_DIR}/dune/*.hh")
-set(COMMON_HEADER ${xtlaheader} ${DUNE_HEADERS})
-
-# add header of dependent modules for header listing
-foreach(_mod ${ALL_DEPENDENCIES})
-        file(GLOB_RECURSE HEADER_LIST "${CMAKE_CURRENT_SOURCE_DIR}/../${_mod}/*.hh")
-        list(APPEND COMMON_HEADER ${HEADER_LIST})
-endforeach(_mod DEPENDENCIES)
-set_source_files_properties(${COMMON_HEADER} PROPERTIES HEADER_FILE_ONLY 1)
-
-#disable most warnings from dependent modules
-foreach(_mod ${ALL_DEPENDENCIES})
-    dune_module_to_uppercase(_upper_case "${_mod}")
-    if(${_mod}_INCLUDE_DIRS)
-        foreach( _idir ${${_mod}_INCLUDE_DIRS} )
-            add_definitions("-isystem ${_idir}")
-        endforeach( _idir )
-    endif(${_mod}_INCLUDE_DIRS)
-endforeach(_mod DEPENDENCIES)
+include(DuneUtils)
 
 add_subdirectory(dune)
 add_subdirectory(doc)
+
+add_header_listing()
+make_dependent_modules_sys_included()
 add_format(${CMAKE_CURRENT_SOURCE_DIR})
 add_tidy(${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/dune/CMakeLists.txt
+++ b/dune/CMakeLists.txt
@@ -6,3 +6,7 @@
 #   Felix Schindler (2016)
 
 add_subdirectory(xt)
+
+install(DIRECTORY xt
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dune/
+        FILES_MATCHING PATTERN "*.hh")

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -207,20 +207,20 @@ public:
 
   void scal(const ScalarType& alpha)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    backend() *= alpha;
+    backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (xx.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of x (" << xx.size() << ") does not match the size of this (" << size() << ")!");
-    auto& this_ref = backend();
-    const auto& xx_ref = xx.backend();
-    for (size_t ii = 0; ii < this_ref.size(); ++ii)
-      this_ref[ii] += alpha * xx_ref[ii];
+    for (size_t ii = 0; ii < backend_ref.size(); ++ii)
+      backend_ref[ii] += alpha * xx.backend()[ii];
   } // ... axpy(...)
 
   bool has_equal_shape(const ThisType& other) const
@@ -239,16 +239,18 @@ public:
 
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < size());
-    backend()[ii] += value;
+    backend_ref[ii] += value;
   }
 
   void set_entry(const size_t ii, const ScalarType& value)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < size());
-    backend()[ii] = value;
+    backend_ref[ii] = value;
   }
 
   ScalarType get_entry(const size_t ii) const
@@ -312,20 +314,22 @@ public:
 
   virtual void iadd(const ThisType& other) override final
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    backend() += other.backend();
+    backend_ref += other.backend();
   } // ... iadd(...)
 
   virtual void isub(const ThisType& other) override final
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    backend() -= other.backend();
+    backend_ref -= other.backend();
   } // ... isub(...)
 
 protected:
@@ -460,12 +464,14 @@ public:
 
   void scal(const ScalarType& alpha)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    backend() *= alpha;
+    backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (!has_equal_shape(xx))
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
@@ -474,7 +480,7 @@ public:
                                      << "x"
                                      << cols()
                                      << ")!");
-    backend().axpy(alpha, xx.backend());
+    backend_ref.axpy(alpha, xx.backend());
   } // ... axpy(...)
 
   bool has_equal_shape(const ThisType& other) const
@@ -510,18 +516,20 @@ public:
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
+    auto& backend_ref = backend();
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < rows());
     assert(jj < cols());
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    backend()[ii][jj] += value;
+    backend_ref[ii][jj] += value;
   } // ... add_to_entry(...)
 
   void set_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
+    auto& backend_ref = backend();
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < rows());
     assert(jj < cols());
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    backend()[ii][jj] = value;
+    backend_ref[ii][jj] = value;
   } // ... set_entry(...)
 
   ScalarType get_entry(const size_t ii, const size_t jj) const
@@ -533,26 +541,28 @@ public:
 
   void clear_row(const size_t ii)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (ii >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the rows of this (" << rows() << ")!");
-    backend()[ii] *= ScalarType(0);
+    backend_ref[ii] *= ScalarType(0);
   } // ... clear_row(...)
 
   void clear_col(const size_t jj)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
-    auto& backend_ref = backend();
     for (size_t ii = 0; ii < rows(); ++ii)
       backend_ref[ii][jj] = ScalarType(0);
   } // ... clear_col(...)
 
   void unit_row(const size_t ii)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (ii >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
@@ -560,7 +570,7 @@ public:
     if (ii >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the rows of this (" << rows() << ")!");
-    auto& row = backend()[ii];
+    auto& row = backend_ref[ii];
     for (size_t jj = 0; jj < cols(); ++jj)
       row[jj] = ScalarType(0);
     row[ii] = ScalarType(1);
@@ -568,6 +578,7 @@ public:
 
   void unit_col(const size_t jj)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
@@ -575,7 +586,6 @@ public:
     if (jj >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the rows of this (" << rows() << ")!");
-    auto& backend_ref = backend();
     for (size_t ii = 0; ii < rows(); ++ii)
       backend_ref[ii][jj] = ScalarType(0);
     backend_ref[jj][jj] = ScalarType(1);
@@ -584,9 +594,8 @@ public:
   bool valid() const
   {
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    const auto& backend_ref = backend();
     for (size_t ii = 0; ii < rows(); ++ii) {
-      const auto& row_vec = backend_ref[ii];
+      const auto& row_vec = backend()[ii];
       for (size_t jj = 0; jj < cols(); ++jj) {
         const auto& entry = row_vec[jj];
         if (Common::isnan(entry) || Common::isinf(entry))
@@ -631,7 +640,6 @@ public:
   typedef typename Traits::ScalarType ScalarType;
   typedef typename Traits::RealType RealType;
   typedef std::vector<size_t> IndexVectorType;
-
 
   /**
   * \brief This is the constructor of interest which creates a sparse matrix.

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -294,18 +294,6 @@ public:
     return backend().infinity_norm();
   }
 
-  virtual void add(const ThisType& other, ThisType& result) const override final
-  {
-    if (other.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    if (result.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of result (" << result.size() << ") does not match the size of this (" << size() << ")!");
-    BackendType& result_ref = result.backend();
-    for (size_t ii = 0; ii < size(); ++ii)
-      result_ref[ii] = backend_->operator[](ii) + other.backend_->operator[](ii);
-  } // ... add(...)
 
   virtual void iadd(const ThisType& other) override final
   {
@@ -315,18 +303,6 @@ public:
     backend() += other.backend();
   } // ... iadd(...)
 
-  virtual void sub(const ThisType& other, ThisType& result) const override final
-  {
-    if (other.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    if (result.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of result (" << result.size() << ") does not match the size of this (" << size() << ")!");
-    BackendType& result_ref = result.backend();
-    for (size_t ii = 0; ii < size(); ++ii)
-      result_ref[ii] = backend_->operator[](ii) - other.backend_->operator[](ii);
-  } // ... sub(...)
 
   virtual void isub(const ThisType& other) override final
   {
@@ -335,15 +311,6 @@ public:
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
     backend() -= other.backend();
   } // ... isub(...)
-
-  /// \}
-  /// \name Imported from VectorInterface.
-  /// \{
-
-  using VectorInterfaceType::add;
-  using VectorInterfaceType::sub;
-
-  /// \}
 
 protected:
   /**

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -248,9 +248,10 @@ public:
     return backend_->operator[](ii);
   } // ... get_entry(...)
 
+protected:
   inline ScalarType& get_entry_ref(const size_t ii)
   {
-    return backend()[ii];
+    return backend_->operator[](ii);
   }
 
   inline const ScalarType& get_entry_ref(const size_t ii) const
@@ -258,14 +259,15 @@ public:
     return backend_->operator[](ii);
   }
 
+public:
   inline ScalarType& operator[](const size_t ii)
   {
-    return get_entry_ref(ii);
+    return backend()[ii];
   }
 
   inline const ScalarType& operator[](const size_t ii) const
   {
-    return get_entry_ref(ii);
+    return backend()[ii];
   }
 
   /// \}

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -903,7 +903,7 @@ private:
   size_t get_entry_index(const size_t rr, const size_t cc, const bool throw_if_not_in_pattern = true) const
   {
     const auto& row_offset = row_pointers_->operator[](rr);
-    const auto& next_row_offset = row_pointers_->operator[](rr+1);
+    const auto& next_row_offset = row_pointers_->operator[](rr + 1);
     const auto column_indices_it = column_indices_->begin() + row_offset;
     const auto column_indices_it_end = column_indices_->begin() + next_row_offset;
     const auto entry_it = std::find(column_indices_it, column_indices_it_end, cc);

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -762,7 +762,6 @@ public:
   inline ThisType copy() const
   {
     ThisType ret(*this);
-    ensure_uniqueness();
     return ret;
   }
 
@@ -887,7 +886,6 @@ public:
                                          const typename Common::FloatCmp::DefaultEpsilon<ScalarType>::Type eps =
                                              Common::FloatCmp::DefaultEpsilon<ScalarType>::value()) const override
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     SparsityPatternDefault ret(num_rows_);
     for (size_t rr = 0; rr < num_rows_; ++rr) {
       for (size_t kk = row_pointers_->operator[](rr + 1); kk < row_pointers_->operator[](rr + 1); ++kk) {
@@ -904,7 +902,6 @@ public:
 private:
   size_t get_entry_index(const size_t rr, const size_t cc, const bool throw_if_not_in_pattern = true) const
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     const auto& row_offset = row_pointers_->operator[](rr);
     const auto& next_row_offset = row_pointers_->operator[](rr+1);
     const auto column_indices_it = column_indices_->begin() + row_offset;

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -176,7 +176,6 @@ public:
 
   const BackendType& backend() const
   {
-    ensure_uniqueness();
     return *backend_;
   } // ... backend(...)
 
@@ -351,7 +350,7 @@ private:
   /**
    * \see ContainerInterface
    */
-  inline void ensure_uniqueness() const
+  inline void ensure_uniqueness()
   {
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
@@ -360,7 +359,7 @@ private:
   friend class VectorInterface<internal::CommonDenseVectorTraits<ScalarType>, ScalarType>;
   friend class CommonDenseMatrix<ScalarType>;
 
-  mutable std::shared_ptr<BackendType> backend_;
+  std::shared_ptr<BackendType> backend_;
 }; // class CommonDenseVector
 
 /**

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -346,7 +346,7 @@ public:
 
   /// \}
 
-private:
+protected:
   /**
    * \see ContainerInterface
    */
@@ -356,6 +356,7 @@ private:
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
 
+private:
   friend class VectorInterface<internal::CommonDenseVectorTraits<ScalarType>, ScalarType>;
   friend class CommonDenseMatrix<ScalarType>;
 
@@ -598,7 +599,7 @@ public:
 
   /// \}
 
-private:
+protected:
   /**
    * \see ContainerInterface
    */
@@ -608,6 +609,7 @@ private:
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
 
+private:
   mutable std::shared_ptr<BackendType> backend_;
 }; // class CommonDenseMatrix
 
@@ -909,12 +911,14 @@ private:
     return size_t(-1);
   }
 
+protected:
   inline void ensure_uniqueness() const
   {
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
 
+private:
   size_t num_rows_, num_cols_;
   mutable std::shared_ptr<BackendType> backend_;
   std::shared_ptr<IndexVectorType> row_pointers_;

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -77,7 +77,7 @@ public:
   typedef typename Dune::FieldTraits<ScalarImp>::field_type ScalarType;
   typedef typename Dune::FieldTraits<ScalarImp>::real_type RealType;
   typedef CommonSparseMatrix<ScalarType> derived_type;
-  typedef std::vector<ScalarType> BackendType;
+  typedef std::vector<ScalarType> EntriesVectorType;
   static const constexpr Backends vector_type = Backends::common_dense;
 };
 
@@ -628,15 +628,14 @@ private:
  * \brief A sparse matrix implementation of the MatrixInterface with row major memory layout.
  */
 template <class ScalarImp = double>
-class CommonSparseMatrix : public MatrixInterface<internal::CommonSparseMatrixTraits<ScalarImp>, ScalarImp>,
-                           public ProvidesBackend<internal::CommonSparseMatrixTraits<ScalarImp>>
+class CommonSparseMatrix : public MatrixInterface<internal::CommonSparseMatrixTraits<ScalarImp>, ScalarImp>
 {
   typedef CommonSparseMatrix<ScalarImp> ThisType;
   typedef MatrixInterface<internal::CommonSparseMatrixTraits<ScalarImp>, ScalarImp> MatrixInterfaceType;
 
 public:
   typedef internal::CommonSparseMatrixTraits<ScalarImp> Traits;
-  typedef typename Traits::BackendType BackendType;
+  typedef typename Traits::EntriesVectorType EntriesVectorType;
   typedef typename Traits::ScalarType ScalarType;
   typedef typename Traits::RealType RealType;
   typedef std::vector<size_t> IndexVectorType;
@@ -647,7 +646,7 @@ public:
   CommonSparseMatrix(const size_t rr, const size_t cc, const SparsityPatternDefault& patt)
     : num_rows_(rr)
     , num_cols_(cc)
-    , backend_(std::make_shared<BackendType>())
+    , entries_(std::make_shared<EntriesVectorType>())
     , row_pointers_(std::make_shared<IndexVectorType>(num_rows_ + 1))
     , column_indices_(std::make_shared<IndexVectorType>())
   {
@@ -671,7 +670,7 @@ public:
 #endif // NDEBUG
           column_indices_->push_back(columns[col]);
         }
-        backend_->resize(column_indices_->size());
+        entries_->resize(column_indices_->size());
       }
     }
   }
@@ -679,7 +678,7 @@ public:
   CommonSparseMatrix(const size_t rr = 0, const size_t cc = 0, const ScalarType& value = ScalarType(0))
     : num_rows_(rr)
     , num_cols_(cc)
-    , backend_(std::make_shared<BackendType>(num_rows_ * num_cols_, value))
+    , entries_(std::make_shared<EntriesVectorType>(num_rows_ * num_cols_, value))
     , row_pointers_(std::make_shared<IndexVectorType>(num_rows_ + 1))
     , column_indices_(std::make_shared<IndexVectorType>())
   {
@@ -702,7 +701,7 @@ public:
   CommonSparseMatrix(const ThisType& other)
     : num_rows_(other.num_rows_)
     , num_cols_(other.num_cols_)
-    , backend_(other.backend_)
+    , entries_(other.entries_)
     , row_pointers_(other.row_pointers_)
     , column_indices_(other.column_indices_)
   {
@@ -716,7 +715,7 @@ public:
           Common::FloatCmp::DefaultEpsilon<ScalarType>::value())
     : num_rows_(Common::MatrixAbstraction<OtherMatrixType>::rows(mat))
     , num_cols_(Common::MatrixAbstraction<OtherMatrixType>::cols(mat))
-    , backend_(std::make_shared<BackendType>())
+    , entries_(std::make_shared<EntriesVectorType>())
     , row_pointers_(std::make_shared<IndexVectorType>(num_rows_ + 1))
     , column_indices_(std::make_shared<IndexVectorType>())
   {
@@ -726,7 +725,7 @@ public:
         const auto& value = Common::MatrixAbstraction<OtherMatrixType>::get_entry(mat, rr, cc);
         if (!prune || XT::Common::FloatCmp::ne(value, ScalarType(0), eps)) {
           ++num_nonzero_entries_in_row;
-          backend_->push_back(value);
+          entries_->push_back(value);
           column_indices_->push_back(cc);
         }
       }
@@ -742,32 +741,18 @@ public:
     Dune::FieldMatrix<ScalarType, ROWS, COLS> ret(ScalarType(0));
     for (size_t rr = 0; rr < ROWS; ++rr)
       for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
-        ret[rr][column_indices_->operator[](kk)] = backend_->operator[](kk);
+        ret[rr][column_indices_->operator[](kk)] = entries_->operator[](kk);
     return ret;
   }
 
   ThisType& operator=(const ThisType& other)
   {
-    backend_ = other.backend_;
+    entries_ = other.entries_;
     row_pointers_ = other.row_pointers_;
     column_indices_ = other.column_indices_;
     num_rows_ = other.num_rows_;
     num_cols_ = other.num_cols_;
     return *this;
-  }
-
-  /// \name Required by the ProvidesBackend interface.
-  /// \{
-
-  BackendType& backend()
-  {
-    ensure_uniqueness();
-    return *backend_;
-  }
-
-  const BackendType& backend() const
-  {
-    return *backend_;
   }
 
   /// \}
@@ -776,7 +761,7 @@ public:
 
   inline ThisType copy() const
   {
-    CommonSparseMatrix ret(*this);
+    ThisType ret(*this);
     ensure_uniqueness();
     return ret;
   }
@@ -786,7 +771,7 @@ public:
     ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     std::transform(
-        backend_->begin(), backend_->end(), backend_->begin(), std::bind1st(std::multiplies<ScalarType>(), alpha));
+        entries_->begin(), entries_->end(), entries_->begin(), std::bind1st(std::multiplies<ScalarType>(), alpha));
   }
 
   inline void axpy(const ScalarType& alpha, const ThisType& xx)
@@ -794,9 +779,9 @@ public:
     ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(has_equal_shape(xx));
-    const auto& xx_backend = xx.backend();
-    for (size_t ii = 0; ii < backend_->size(); ++ii)
-      backend_->operator[](ii) += alpha * xx_backend[ii];
+    const auto& xx_entries = *xx.entries_;
+    for (size_t ii = 0; ii < entries_->size(); ++ii)
+      entries_->operator[](ii) += alpha * xx_entries[ii];
   }
 
   inline bool has_equal_shape(const ThisType& other) const
@@ -825,40 +810,36 @@ public:
     std::fill(yy.begin(), yy.end(), ScalarType(0));
     for (size_t rr = 0; rr < num_rows_; ++rr)
       for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
-        yy[rr] += backend_->operator[](kk) * xx[column_indices_->operator[](kk)];
+        yy[rr] += entries_->operator[](kk) * xx[column_indices_->operator[](kk)];
   }
 
   inline void add_to_entry(const size_t rr, const size_t cc, const ScalarType& value)
   {
     ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    const size_t index = get_index_in_backend(rr, cc);
-    assert(index != size_t(-1) && "Entry has to be in the sparsity pattern!");
-    backend_->operator[](index) += value;
+    entries_->operator[](get_entry_index(rr, cc)) += value;
   }
 
   inline ScalarType get_entry(const size_t rr, const size_t cc) const
   {
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    const size_t index = get_index_in_backend(rr, cc);
-    return index == size_t(-1) ? ScalarType(0) : backend_->operator[](index);
+    const size_t index = get_entry_index(rr, cc, false);
+    return index == size_t(-1) ? ScalarType(0) : entries_->operator[](index);
   }
 
   inline void set_entry(const size_t rr, const size_t cc, const ScalarType value)
   {
     ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    const size_t index = get_index_in_backend(rr, cc);
-    assert(index != size_t(-1) && "Entry has to be in the sparsity pattern!");
-    backend_->operator[](index) = value;
+    entries_->operator[](get_entry_index(rr, cc)) = value;
   }
 
   inline void clear_row(const size_t rr)
   {
     ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    std::fill(backend_->begin() + row_pointers_->operator[](rr),
-              backend_->begin() + row_pointers_->operator[](rr + 1),
+    std::fill(entries_->begin() + row_pointers_->operator[](rr),
+              entries_->begin() + row_pointers_->operator[](rr + 1),
               ScalarType(0));
   }
 
@@ -866,9 +847,9 @@ public:
   {
     ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    for (size_t kk = 0; kk < backend_->size(); ++kk) {
+    for (size_t kk = 0; kk < entries_->size(); ++kk) {
       if (column_indices_->operator[](kk) == cc)
-        backend_->operator[](kk) = ScalarType(0);
+        entries_->operator[](kk) = ScalarType(0);
     }
   }
 
@@ -890,7 +871,7 @@ public:
   {
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     // iterate over non-zero entries
-    for (const auto& entry : *backend_)
+    for (const auto& entry : *entries_)
       if (XT::Common::isnan(std::real(entry)) || XT::Common::isnan(std::imag(entry))
           || XT::Common::isinf(std::abs(entry)))
         return false;
@@ -899,7 +880,7 @@ public:
 
   virtual size_t non_zeros() const override final
   {
-    return backend_->size();
+    return entries_->size();
   }
 
   virtual SparsityPatternDefault pattern(const bool prune = false,
@@ -910,7 +891,7 @@ public:
     SparsityPatternDefault ret(num_rows_);
     for (size_t rr = 0; rr < num_rows_; ++rr) {
       for (size_t kk = row_pointers_->operator[](rr + 1); kk < row_pointers_->operator[](rr + 1); ++kk) {
-        const auto& val = backend_->operator[](kk);
+        const auto& val = entries_->operator[](kk);
         if (!prune || Common::FloatCmp::ne(val, ScalarType(0), eps))
           ret.insert(rr, column_indices_->operator[](kk));
       }
@@ -921,30 +902,33 @@ public:
   /// \}
 
 private:
-  size_t get_index_in_backend(const size_t rr, const size_t cc) const
+  size_t get_entry_index(const size_t rr, const size_t cc, const bool throw_if_not_in_pattern = true) const
   {
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     const auto& row_offset = row_pointers_->operator[](rr);
-    auto column_indices_iterator = column_indices_->begin();
-    column_indices_iterator += row_offset;
-    for (size_t kk = row_offset; kk < row_pointers_->operator[](rr + 1); ++kk, ++column_indices_iterator)
-      if (*column_indices_iterator == cc)
-        return kk;
+    const auto& next_row_offset = row_pointers_->operator[](rr+1);
+    const auto column_indices_it = column_indices_->begin() + row_offset;
+    const auto column_indices_it_end = column_indices_->begin() + next_row_offset;
+    const auto entry_it = std::find(column_indices_it, column_indices_it_end, cc);
+    if (entry_it != column_indices_it_end)
+      return row_offset + std::distance(column_indices_it, entry_it);
+    if (throw_if_not_in_pattern)
+      DUNE_THROW(Common::Exceptions::index_out_of_range, "Entry is not in the sparsity pattern!");
     return size_t(-1);
   }
 
 protected:
   inline void ensure_uniqueness()
   {
-    if (!backend_.unique()) {
+    if (!entries_.unique()) {
       std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-      backend_ = std::make_shared<BackendType>(*backend_);
+      entries_ = std::make_shared<EntriesVectorType>(*entries_);
     }
   } // ... ensure_uniqueness(...)
 
 private:
   size_t num_rows_, num_cols_;
-  std::shared_ptr<BackendType> backend_;
+  std::shared_ptr<EntriesVectorType> entries_;
   std::shared_ptr<IndexVectorType> row_pointers_;
   std::shared_ptr<IndexVectorType> column_indices_;
   mutable std::mutex mutex_;

--- a/dune/xt/la/container/container-interface.hh
+++ b/dune/xt/la/container/container-interface.hh
@@ -176,6 +176,13 @@ public:
     return this->as_imp().has_equal_shape(other);
   }
 
+protected:
+  inline void ensure_uniqueness()
+  {
+    CHECK_AND_CALL_CRTP(this->as_imp().ensure_uniqueness());
+  }
+
+public:
   /// \}
   /// \name Are provided by the interface for convenience!
   /// \note Those marked as virtual may be implemented more efficiently in a derived class!

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -17,6 +17,7 @@
 #include <type_traits>
 #include <vector>
 #include <complex>
+#include <mutex>
 
 #include <dune/xt/common/disable_warnings.hh>
 #if HAVE_EIGEN
@@ -26,6 +27,7 @@
 
 #include <dune/common/typetraits.hh>
 #include <dune/common/ftraits.hh>
+#include <dune/common/unused.hh>
 
 #include <dune/xt/common/exceptions.hh>
 #include <dune/xt/common/crtp.hh>
@@ -99,17 +101,20 @@ public:
 
   VectorImpType copy() const
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return VectorImpType(*backend_);
   }
 
   void scal(const ScalarType& alpha)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     backend() *= alpha;
   }
 
   template <class T>
   void axpy(const ScalarType& alpha, const EigenBaseVector<T, ScalarType>& xx)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (xx.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of xx (" << xx.size() << ") does not match the size of this (" << size() << ")!");
@@ -132,12 +137,14 @@ public:
 
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < size());
     backend()(ii) += value;
   }
 
   void set_entry(const size_t ii, const ScalarType& value)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < size());
     backend()(ii) = value;
   }
@@ -177,6 +184,7 @@ public:
 
   virtual std::pair<size_t, RealType> amax() const override final
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     auto result = std::make_pair(size_t(0), RealType(0));
     size_t min_index = 0;
     size_t max_index = 0;
@@ -195,6 +203,7 @@ public:
   template <class T>
   ScalarType dot(const EigenBaseVector<T, ScalarType>& other) const
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -208,22 +217,26 @@ public:
 
   virtual RealType l1_norm() const override final
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return backend().template lpNorm<1>();
   }
 
   virtual RealType l2_norm() const override final
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return backend().template lpNorm<2>();
   }
 
   virtual RealType sup_norm() const override final
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return backend().template lpNorm<::Eigen::Infinity>();
   }
 
   template <class T>
   void iadd(const EigenBaseVector<T, ScalarType>& other)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -238,6 +251,7 @@ public:
   template <class T>
   void isub(const EigenBaseVector<T, ScalarType>& other)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -276,6 +290,7 @@ private:
 
 protected:
   std::shared_ptr<BackendType> backend_;
+  mutable std::mutex mutex_;
 }; // class EigenBaseVector
 
 #else // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -107,18 +107,20 @@ public:
 
   void scal(const ScalarType& alpha)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    backend() *= alpha;
+    backend_ref *= alpha;
   }
 
   template <class T>
   void axpy(const ScalarType& alpha, const EigenBaseVector<T, ScalarType>& xx)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (xx.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of xx (" << xx.size() << ") does not match the size of this (" << size() << ")!");
-    backend() += alpha * xx.backend();
+    backend_ref += alpha * xx.backend();
   } // ... axpy(...)
 
   bool has_equal_shape(const VectorImpType& other) const
@@ -137,16 +139,18 @@ public:
 
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < size());
-    backend()(ii) += value;
+    backend_ref(ii) += value;
   }
 
   void set_entry(const size_t ii, const ScalarType& value)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < size());
-    backend()(ii) = value;
+    backend_ref(ii) = value;
   }
 
   ScalarType get_entry(const size_t ii) const
@@ -207,7 +211,7 @@ public:
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    return backend_->transpose() * other.backend();
+    return backend().transpose() * other.backend();
   } // ... dot(...)
 
   virtual ScalarType dot(const VectorImpType& other) const override final
@@ -236,11 +240,12 @@ public:
   template <class T>
   void iadd(const EigenBaseVector<T, ScalarType>& other)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    backend() += other.backend();
+    backend_ref += other.backend();
   } // ... iadd(...)
 
   virtual void iadd(const VectorImpType& other) override final
@@ -251,11 +256,12 @@ public:
   template <class T>
   void isub(const EigenBaseVector<T, ScalarType>& other)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    backend() -= *(other.backend_);
+    backend_ref -= *(other.backend_);
   } // ... isub(...)
 
   virtual void isub(const VectorImpType& other) override final

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -145,7 +145,7 @@ public:
   ScalarType get_entry(const size_t ii) const
   {
     assert(ii < size());
-    return backend_->operator[](ii);
+    return backend()[ii];
   }
 
 protected:
@@ -198,7 +198,7 @@ public:
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    return backend_->transpose() * *(other.backend_);
+    return backend_->transpose() * other.backend();
   } // ... dot(...)
 
   virtual ScalarType dot(const VectorImpType& other) const override final
@@ -208,17 +208,17 @@ public:
 
   virtual RealType l1_norm() const override final
   {
-    return backend_->template lpNorm<1>();
+    return backend().template lpNorm<1>();
   }
 
   virtual RealType l2_norm() const override final
   {
-    return backend_->template lpNorm<2>();
+    return backend().template lpNorm<2>();
   }
 
   virtual RealType sup_norm() const override final
   {
-    return backend_->template lpNorm<::Eigen::Infinity>();
+    return backend().template lpNorm<::Eigen::Infinity>();
   }
 
   template <class T1, class T2>
@@ -244,7 +244,7 @@ public:
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    backend() += *(other.backend_);
+    backend() += other.backend();
   } // ... iadd(...)
 
   virtual void iadd(const VectorImpType& other) override final

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -286,7 +286,7 @@ public:
   //! disambiguation necessary since it exists in multiple bases
   using VectorInterfaceType::as_imp;
 
-private:
+protected:
   /**
    * \see ContainerInterface
    */
@@ -296,6 +296,7 @@ private:
     VectorInterfaceType::as_imp().ensure_uniqueness();
   }
 
+private:
 #ifndef NDEBUG
   //! disambiguation necessary since it exists in multiple bases
   using VectorInterfaceType::crtp_mutex_;

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -90,7 +90,6 @@ public:
 
   const BackendType& backend() const
   {
-    ensure_uniqueness();
     return *backend_;
   }
 
@@ -291,7 +290,7 @@ private:
   /**
    * \see ContainerInterface
    */
-  void ensure_uniqueness() const
+  void ensure_uniqueness()
   {
     CHECK_AND_CALL_CRTP(VectorInterfaceType::as_imp().ensure_uniqueness());
     VectorInterfaceType::as_imp().ensure_uniqueness();
@@ -307,7 +306,7 @@ private:
   friend class EigenRowMajorSparseMatrix<ScalarType>;
 
 protected:
-  mutable std::shared_ptr<BackendType> backend_;
+  std::shared_ptr<BackendType> backend_;
 }; // class EigenBaseVector
 
 #else // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -221,23 +221,6 @@ public:
     return backend().template lpNorm<::Eigen::Infinity>();
   }
 
-  template <class T1, class T2>
-  void add(const EigenBaseVector<T1, ScalarType>& other, EigenBaseVector<T2, ScalarType>& result) const
-  {
-    if (other.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    if (result.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of result (" << result.size() << ") does not match the size of this (" << size() << ")!");
-    result.backend() = *backend_ + *(other.backend_);
-  } // ... add(...)
-
-  virtual void add(const VectorImpType& other, VectorImpType& result) const override final
-  {
-    return this->template add<Traits, Traits>(other, result);
-  }
-
   template <class T>
   void iadd(const EigenBaseVector<T, ScalarType>& other)
   {
@@ -250,23 +233,6 @@ public:
   virtual void iadd(const VectorImpType& other) override final
   {
     return this->template iadd<Traits>(other);
-  }
-
-  template <class T1, class T2>
-  void sub(const EigenBaseVector<T1, ScalarType>& other, EigenBaseVector<T2, ScalarType>& result) const
-  {
-    if (other.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    if (result.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of result (" << result.size() << ") does not match the size of this (" << size() << ")!");
-    result.backend() = *backend_ - *(other.backend_);
-  } // ... sub(...)
-
-  virtual void sub(const VectorImpType& other, VectorImpType& result) const override final
-  {
-    return this->template sub<Traits, Traits>(other, result);
   }
 
   template <class T>

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -148,24 +148,26 @@ public:
     return backend_->operator[](ii);
   }
 
+protected:
   inline ScalarType& get_entry_ref(const size_t ii)
   {
-    return backend()[ii];
+    return backend_[ii];
   }
 
   inline const ScalarType& get_entry_ref(const size_t ii) const
   {
-    return backend()[ii];
+    return backend_[ii];
   }
 
+public:
   inline ScalarType& operator[](const size_t ii)
   {
-    return get_entry_ref(ii);
+    return backend()[ii];
   }
 
   inline const ScalarType& operator[](const size_t ii) const
   {
-    return get_entry_ref(ii);
+    return backend()[ii];
   }
 
   /// \}

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -196,7 +196,7 @@ public:
 private:
   using BaseType::backend_;
 
-  inline void ensure_uniqueness() const
+  inline void ensure_uniqueness()
   {
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*(backend_));
@@ -434,7 +434,6 @@ public:
 
   const BackendType& backend() const
   {
-    ensure_uniqueness();
     return *backend_;
   }
 
@@ -585,13 +584,13 @@ public:
    */
 
 private:
-  inline void ensure_uniqueness() const
+  inline void ensure_uniqueness()
   {
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
 
-  mutable std::shared_ptr<BackendType> backend_;
+  std::shared_ptr<BackendType> backend_;
 }; // class EigenDenseMatrix
 
 #else // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -196,12 +196,14 @@ public:
 private:
   using BaseType::backend_;
 
+protected:
   inline void ensure_uniqueness()
   {
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*(backend_));
   } // ... ensure_uniqueness(...)
 
+private:
   friend class EigenBaseVector<internal::EigenDenseVectorTraits<ScalarType>, ScalarType>;
 }; // class EigenDenseVector
 
@@ -313,6 +315,7 @@ public:
 private:
   using BaseType::backend_;
 
+protected:
   inline void ensure_uniqueness() const
   {
     if (!backend_.unique()) {
@@ -322,6 +325,7 @@ private:
     }
   } // ... ensure_uniqueness(...)
 
+private:
   friend class EigenBaseVector<internal::EigenMappedDenseVectorTraits<ScalarType>, ScalarType>;
 }; // class EigenMappedDenseVector
 
@@ -583,13 +587,14 @@ public:
    * \}
    */
 
-private:
+protected:
   inline void ensure_uniqueness()
   {
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
 
+private:
   std::shared_ptr<BackendType> backend_;
 }; // class EigenDenseMatrix
 

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -473,8 +473,7 @@ public:
                                      << "x"
                                      << cols()
                                      << ")!");
-    const auto& xx_ref = *(xx.backend_);
-    backend() += alpha * xx_ref;
+    backend() += alpha * xx.backend();
   } // ... axpy(...)
 
   bool has_equal_shape(const ThisType& other) const
@@ -499,7 +498,7 @@ public:
   template <class T1, class T2>
   inline void mv(const EigenBaseVector<T1, ScalarType>& xx, EigenBaseVector<T2, ScalarType>& yy) const
   {
-    yy.backend().transpose() = backend_->operator*(*xx.backend_);
+    yy.backend().transpose() = backend() * xx.backend();
   }
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
@@ -520,7 +519,7 @@ public:
   {
     assert(ii < rows());
     assert(jj < cols());
-    return backend_->operator()(ii, jj);
+    return backend()(ii, jj);
   } // ... get_entry(...)
 
   void clear_row(const size_t ii)

--- a/dune/xt/la/container/eigen/sparse.hh
+++ b/dune/xt/la/container/eigen/sparse.hh
@@ -423,12 +423,13 @@ private:
     return false;
   } // ... these_are_valid_indices(...)
 
+protected:
   inline void ensure_uniqueness()
   {
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
-
+private:
   std::shared_ptr<BackendType> backend_;
 }; // class EigenRowMajorSparseMatrix
 

--- a/dune/xt/la/container/eigen/sparse.hh
+++ b/dune/xt/la/container/eigen/sparse.hh
@@ -17,6 +17,7 @@
 #include <type_traits>
 #include <vector>
 #include <complex>
+#include <mutex>
 
 #include <boost/numeric/conversion/cast.hpp>
 
@@ -28,6 +29,7 @@
 
 #include <dune/common/typetraits.hh>
 #include <dune/common/ftraits.hh>
+#include <dune/common/unused.hh>
 
 #include <dune/xt/common/math.hh>
 #include <dune/xt/common/exceptions.hh>
@@ -187,6 +189,7 @@ public:
    */
   ThisType& operator=(const BackendType& other)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     backend_ = std::make_shared<BackendType>(other);
     return *this;
   }
@@ -211,16 +214,19 @@ public:
 
   ThisType copy() const
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return ThisType(*backend_);
   }
 
   void scal(const ScalarType& alpha)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     backend() *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (!has_equal_shape(xx))
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The shape of xx (" << xx.rows() << "x" << xx.cols() << ") does not match the shape of this ("
@@ -253,11 +259,13 @@ public:
   template <class T1, class T2>
   inline void mv(const EigenBaseVector<T1, ScalarType>& xx, EigenBaseVector<T2, ScalarType>& yy) const
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     yy.backend().transpose() = backend() * xx.backend();
   }
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(these_are_valid_indices(ii, jj));
     backend().coeffRef(internal::boost_numeric_cast<EIGEN_size_t>(ii),
                        internal::boost_numeric_cast<EIGEN_size_t>(jj)) += value;
@@ -265,6 +273,7 @@ public:
 
   void set_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(these_are_valid_indices(ii, jj));
     backend().coeffRef(internal::boost_numeric_cast<EIGEN_size_t>(ii), internal::boost_numeric_cast<EIGEN_size_t>(jj)) =
         value;
@@ -272,6 +281,7 @@ public:
 
   ScalarType get_entry(const size_t ii, const size_t jj) const
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < rows());
     assert(jj < cols());
     return backend().coeff(internal::boost_numeric_cast<EIGEN_size_t>(ii),
@@ -280,6 +290,7 @@ public:
 
   void clear_row(const size_t ii)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (ii >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the rows of this (" << rows() << ")!");
@@ -289,6 +300,7 @@ public:
   void clear_col(const size_t jj)
   {
     ensure_uniqueness();
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -309,6 +321,7 @@ public:
 
   void unit_row(const size_t ii)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (ii >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the cols of this (" << cols() << ")!");
@@ -325,6 +338,7 @@ public:
   void unit_col(const size_t jj)
   {
     ensure_uniqueness();
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -352,6 +366,7 @@ public:
 
   bool valid() const
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     // iterate over non-zero entries
     typedef typename BackendType::InnerIterator InnerIterator;
     for (EIGEN_size_t ii = 0; ii < backend_->outerSize(); ++ii) {
@@ -372,6 +387,7 @@ public:
   pattern(const bool prune = false,
           const ScalarType eps = Common::FloatCmp::DefaultEpsilon<ScalarType>::value()) const override
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     SparsityPatternDefault ret(rows());
     const auto zero = typename Common::FloatCmp::DefaultEpsilon<ScalarType>::Type(0);
     if (prune) {
@@ -396,6 +412,7 @@ public:
   virtual ThisType
   pruned(const ScalarType eps = Common::FloatCmp::DefaultEpsilon<ScalarType>::value()) const override final
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return ThisType(*backend_, true, eps);
   }
 
@@ -425,12 +442,15 @@ private:
 protected:
   inline void ensure_uniqueness()
   {
-    if (!backend_.unique())
+    if (!backend_.unique()) {
+      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
       backend_ = std::make_shared<BackendType>(*backend_);
+    }
   } // ... ensure_uniqueness(...)
 
 private:
   std::shared_ptr<BackendType> backend_;
+  mutable std::mutex mutex_;
 }; // class EigenRowMajorSparseMatrix
 
 #else // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/sparse.hh
+++ b/dune/xt/la/container/eigen/sparse.hh
@@ -202,7 +202,6 @@ public:
 
   const BackendType& backend() const
   {
-    ensure_uniqueness();
     return *backend_;
   }
 
@@ -424,13 +423,13 @@ private:
     return false;
   } // ... these_are_valid_indices(...)
 
-  inline void ensure_uniqueness() const
+  inline void ensure_uniqueness()
   {
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
 
-  mutable std::shared_ptr<BackendType> backend_;
+  std::shared_ptr<BackendType> backend_;
 }; // class EigenRowMajorSparseMatrix
 
 #else // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/sparse.hh
+++ b/dune/xt/la/container/eigen/sparse.hh
@@ -217,7 +217,7 @@ public:
   void scal(const ScalarType& alpha)
   {
     backend() *= alpha;
-  } // ... scal(...)
+  }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
@@ -228,8 +228,7 @@ public:
                                      << "x"
                                      << cols()
                                      << ")!");
-    const auto& xx_ref = *(xx.backend_);
-    backend() += alpha * xx_ref;
+    backend() += alpha * xx.backend();
   } // ... axpy(...)
 
   bool has_equal_shape(const ThisType& other) const
@@ -254,7 +253,7 @@ public:
   template <class T1, class T2>
   inline void mv(const EigenBaseVector<T1, ScalarType>& xx, EigenBaseVector<T2, ScalarType>& yy) const
   {
-    yy.backend().transpose() = backend_->operator*(*xx.backend_);
+    yy.backend().transpose() = backend() * xx.backend();
   }
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
@@ -275,7 +274,7 @@ public:
   {
     assert(ii < rows());
     assert(jj < cols());
-    return backend_->coeff(internal::boost_numeric_cast<EIGEN_size_t>(ii),
+    return backend().coeff(internal::boost_numeric_cast<EIGEN_size_t>(ii),
                            internal::boost_numeric_cast<EIGEN_size_t>(jj));
   }
 
@@ -289,10 +288,10 @@ public:
 
   void clear_col(const size_t jj)
   {
+    ensure_uniqueness();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
-    ensure_uniqueness();
     for (size_t row = 0; internal::boost_numeric_cast<EIGEN_size_t>(row) < backend_->outerSize(); ++row) {
       for (typename BackendType::InnerIterator row_it(*backend_, internal::boost_numeric_cast<EIGEN_size_t>(row));
            row_it;
@@ -325,13 +324,13 @@ public:
 
   void unit_col(const size_t jj)
   {
+    ensure_uniqueness();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
     if (jj >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the rows of this (" << rows() << ")!");
-    ensure_uniqueness();
     for (size_t row = 0; internal::boost_numeric_cast<EIGEN_size_t>(row) < backend_->outerSize(); ++row) {
       for (typename BackendType::InnerIterator row_it(*backend_, internal::boost_numeric_cast<EIGEN_size_t>(row));
            row_it;
@@ -429,6 +428,7 @@ protected:
     if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
+
 private:
   std::shared_ptr<BackendType> backend_;
 }; // class EigenRowMajorSparseMatrix

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -294,28 +294,6 @@ public:
     return backend().infinity_norm();
   }
 
-  virtual void add(const ThisType& other, ThisType& result) const override final
-  {
-    if (other.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    if (result.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of result (" << result.size() << ") does not match the size of this (" << size() << ")!");
-    result.backend() = *(backend_);
-    result.backend() += *(other.backend_);
-  } // ... add(...)
-
-  virtual ThisType add(const ThisType& other) const override final
-  {
-    if (other.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    ThisType result = copy();
-    result.backend_->operator+=(*(other.backend_));
-    return result;
-  } // ... add(...)
-
   virtual void iadd(const ThisType& other) override final
   {
     if (other.size() != size())
@@ -323,28 +301,6 @@ public:
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
     backend() += other.backend();
   } // ... iadd(...)
-
-  virtual void sub(const ThisType& other, ThisType& result) const override final
-  {
-    if (other.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    if (result.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of result (" << result.size() << ") does not match the size of this (" << size() << ")!");
-    result.backend() = *(backend_);
-    result.backend() -= *(other.backend_);
-  } // ... sub(...)
-
-  virtual ThisType sub(const ThisType& other) const override final
-  {
-    if (other.size() != size())
-      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    ThisType result = copy();
-    result.backend_->operator-=(*(other.backend_));
-    return result;
-  } // ... sub(...)
 
   virtual void isub(const ThisType& other) override final
   {

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -592,7 +592,6 @@ public:
   void unit_col(const size_t jj)
   {
     ensure_uniqueness();
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -602,12 +601,14 @@ public:
     if (!backend_->exists(jj, jj))
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Diagonal entry (" << jj << ", " << jj << ") is not contained in the sparsity pattern!");
+    mutex_.lock();
     for (size_t ii = 0; (ii < rows()) && (ii != jj); ++ii) {
       auto& row = backend_->operator[](ii);
       const auto search_result = row.find(jj);
       if (search_result != row.end())
         row.operator[](jj)[0][0] = ScalarType(0);
     }
+    mutex_.unlock();
     set_entry(jj, jj, ScalarType(1));
   } // ... unit_col(...)
 

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -246,9 +246,10 @@ public:
     return backend_->operator[](ii)[0];
   }
 
+protected:
   inline ScalarType& get_entry_ref(const size_t ii)
   {
-    return backend()[ii][0];
+    return backend_->operator[](ii)[0];
   }
 
   inline const ScalarType& get_entry_ref(const size_t ii) const
@@ -256,14 +257,15 @@ public:
     return backend_->operator[](ii)[0];
   }
 
+public:
   inline ScalarType& operator[](const size_t ii)
   {
-    return get_entry_ref(ii);
+    return backend()[ii][0];
   }
 
   inline const ScalarType& operator[](const size_t ii) const
   {
-    return get_entry_ref(ii);
+    return backend_->operator[](ii)[0];
   }
 
   /// \}

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -207,17 +207,19 @@ public:
 
   void scal(const ScalarType& alpha)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    backend() *= alpha;
+    backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (xx.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of x (" << xx.size() << ") does not match the size of this (" << size() << ")!");
-    backend().axpy(alpha, *(xx.backend_));
+    backend_ref.axpy(alpha, xx.backend());
   }
 
   bool has_equal_shape(const ThisType& other) const
@@ -239,16 +241,18 @@ public:
 
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < size());
-    backend()[ii][0] += value;
+    backend_ref[ii][0] += value;
   }
 
   void set_entry(const size_t ii, const ScalarType& value)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(ii < size());
-    backend()[ii][0] = value;
+    backend_ref[ii][0] = value;
   }
 
   ScalarType get_entry(const size_t ii) const
@@ -312,20 +316,22 @@ public:
 
   virtual void iadd(const ThisType& other) override final
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    backend() += other.backend();
+    backend_ref += other.backend();
   } // ... iadd(...)
 
   virtual void isub(const ThisType& other) override final
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
-    backend() -= other.backend();
+    backend_ref -= other.backend();
   } // ... isub(...)
 
   /// \}
@@ -469,12 +475,14 @@ public:
 
   void scal(const ScalarType& alpha)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    backend() *= alpha;
+    backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (!has_equal_shape(xx))
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
@@ -483,7 +491,7 @@ public:
                                      << "x"
                                      << cols()
                                      << ")!");
-    backend().axpy(alpha, xx.backend());
+    backend_ref.axpy(alpha, xx.backend());
   } // ... axpy(...)
 
   bool has_equal_shape(const ThisType& other) const
@@ -507,23 +515,26 @@ public:
 
   inline void mv(const IstlDenseVector<ScalarType>& xx, IstlDenseVector<ScalarType>& yy) const
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     DUNE_XT_COMMON_TIMING_SCOPE(static_id() + ".mv");
-    backend().mv(xx.backend(), yy.backend());
+    auto& backend_ref = backend();
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    backend_ref.mv(xx.backend(), yy.backend());
   }
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(these_are_valid_indices(ii, jj));
-    backend()[ii][jj][0][0] += value;
+    backend_ref[ii][jj][0][0] += value;
   }
 
   void set_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     assert(these_are_valid_indices(ii, jj));
-    backend()[ii][jj][0][0] = value;
+    backend_ref[ii][jj][0][0] = value;
   }
 
   ScalarType get_entry(const size_t ii, const size_t jj) const
@@ -538,11 +549,12 @@ public:
 
   void clear_row(const size_t ii)
   {
+    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (ii >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the rows of this (" << rows() << ")!");
-    backend()[ii] *= ScalarType(0);
+    backend_ref[ii] *= ScalarType(0);
   } // ... clear_row(...)
 
   void clear_col(const size_t jj)

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -355,7 +355,7 @@ public:
 
   /// \}
 
-private:
+protected:
   /**
    * \see ContainerInterface
    */
@@ -365,6 +365,7 @@ private:
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
 
+private:
   friend class VectorInterface<internal::IstlDenseVectorTraits<ScalarType>, ScalarType>;
   friend class IstlRowMajorSparseMatrix<ScalarType>;
 
@@ -703,6 +704,7 @@ private:
     return backend_->exists(ii, jj);
   } // ... these_are_valid_indices(...)
 
+protected:
   /**
    * \see ContainerInterface
    */
@@ -712,6 +714,7 @@ private:
       backend_ = std::make_shared<BackendType>(*backend_);
   } // ... ensure_uniqueness(...)
 
+private:
   mutable std::shared_ptr<BackendType> backend_;
 }; // class IstlRowMajorSparseMatrix
 

--- a/dune/xt/la/container/vector-interface.hh
+++ b/dune/xt/la/container/vector-interface.hh
@@ -84,7 +84,6 @@ public:
 
   /**
    * \brief Get the iith entry.
-   * \todo  Default implement using get_entry_ref!
    */
   inline ScalarType get_entry(const size_t ii) const
   {
@@ -92,6 +91,11 @@ public:
     return this->as_imp().get_entry(ii);
   }
 
+protected:
+  /**
+   * The purpose of get_entry_ref is to allow direct access to the underlying data without any checks (regarding cow
+   * or thread safety). This allows default implementations in the interface with locking prior to for-loops.
+   */
   inline ScalarType& get_entry_ref(const size_t ii)
   {
     CHECK_CRTP(this->as_imp().get_entry_ref(ii));
@@ -104,6 +108,7 @@ public:
     return this->as_imp().get_entry_ref(ii);
   }
 
+public:
   /// \}
   /// \name Provided by the interface for convenience!
   /// \note Those marked as virtual may be implemented more efficiently in a derived class!

--- a/dune/xt/la/test/CMakeLists.txt
+++ b/dune/xt/la/test/CMakeLists.txt
@@ -7,6 +7,8 @@
 
 enable_testing()
 
+set_source_files_properties( ${DUNE_HEADERS} PROPERTIES HEADER_FILE_ONLY 1 )
+
 BEGIN_TESTCASES(dunextla)
 
 END_TESTCASES()

--- a/dune/xt/la/test/container.hh
+++ b/dune/xt/la/test/container.hh
@@ -57,6 +57,19 @@ public:
   }
 };
 
+template <class S>
+class ContainerFactory<Dune::XT::LA::CommonSparseMatrix<S>>
+{
+public:
+  static Dune::XT::LA::CommonSparseMatrix<S> create(const size_t size)
+  {
+    Dune::XT::LA::CommonSparseMatrix<S> matrix(size, size);
+    for (size_t ii = 0; ii < size; ++ii)
+      matrix.unit_row(ii);
+    return matrix;
+  }
+};
+
 #if HAVE_DUNE_ISTL
 template <class S>
 class ContainerFactory<Dune::XT::LA::IstlDenseVector<S>>

--- a/dune/xt/la/test/matrices.mini
+++ b/dune/xt/la/test/matrices.mini
@@ -3,4 +3,4 @@ __local.matrix_eigen = EigenRowMajorSparseMatrix, EigenDenseMatrix | expand
 __local.matrix_istl = IstlRowMajorSparseMatrix
 matrix = {__local.matrix_common}, {__local.matrix_eigen}, {__local.matrix_istl} | expand types
 
-1, EIGEN_FOUND, dune-istl_FOUND | expand types | cmake_guard
+1, EIGEN3_FOUND, dune-istl_FOUND | expand types | cmake_guard

--- a/dune/xt/la/test/matrices.mini
+++ b/dune/xt/la/test/matrices.mini
@@ -3,4 +3,4 @@ __local.matrix_eigen = EigenRowMajorSparseMatrix, EigenDenseMatrix | expand
 __local.matrix_istl = IstlRowMajorSparseMatrix
 matrix = {__local.matrix_common}, {__local.matrix_eigen}, {__local.matrix_istl} | expand types
 
-1, EIGEN3_FOUND, dune-istl_FOUND | expand types | cmake_guard
+1, EIGEN_FOUND, dune-istl_FOUND | expand types | cmake_guard

--- a/dune/xt/la/test/matrices.mini
+++ b/dune/xt/la/test/matrices.mini
@@ -1,4 +1,4 @@
-__local.matrix_common = CommonDenseMatrix
+__local.matrix_common = CommonDenseMatrix, CommonSparseMatrix | expand
 __local.matrix_eigen = EigenRowMajorSparseMatrix, EigenDenseMatrix | expand
 __local.matrix_istl = IstlRowMajorSparseMatrix
 matrix = {__local.matrix_common}, {__local.matrix_eigen}, {__local.matrix_istl} | expand types

--- a/dune/xt/la/test/solver.mini
+++ b/dune/xt/la/test/solver.mini
@@ -8,6 +8,7 @@ __local.vector_eigen2 = EigenDenseVector, EigenMappedDenseVector | expand
 vector2 = {__local.vector_common}, {__local.vector_eigen2}, {__local.vector_istl} | expand types
 
 ('{vector}' == 'EigenMappedDenseVector' or '{vector2}' == 'EigenMappedDenseVector') and '{matrix}' == 'EigenRowMajorSparseMatrix'  | exclude
+'{matrix}' == 'CommonSparseMatrix'  | exclude
 '{matrix}' == 'IstlRowMajorSparseMatrix' and '{fieldtype_short}' == 'complex'  | exclude
 
 [__static]

--- a/dune/xt/la/test/vectors.mini
+++ b/dune/xt/la/test/vectors.mini
@@ -6,6 +6,4 @@ __local.vector_eigen = EigenDenseVector, EigenMappedDenseVector | expand
 __local.vector_istl = IstlDenseVector
 vector = {__local.vector_common}, {__local.vector_eigen}, {__local.vector_istl} | expand types
 
-1, EIGEN3_FOUND, dune-istl_FOUND | expand types | cmake_guard
-
-{fieldtype} == std::complex<double> and {__local.vector_eigen} ==  EigenMappedDenseVector | exclude
+1, EIGEN_FOUND, dune-istl_FOUND | expand types | cmake_guard

--- a/dune/xt/la/test/vectors.mini
+++ b/dune/xt/la/test/vectors.mini
@@ -6,4 +6,6 @@ __local.vector_eigen = EigenDenseVector, EigenMappedDenseVector | expand
 __local.vector_istl = IstlDenseVector
 vector = {__local.vector_common}, {__local.vector_eigen}, {__local.vector_istl} | expand types
 
-1, EIGEN_FOUND, dune-istl_FOUND | expand types | cmake_guard
+1, EIGEN3_FOUND, dune-istl_FOUND | expand types | cmake_guard
+
+{fieldtype} == std::complex<double> and {__local.vector_eigen} ==  EigenMappedDenseVector | exclude


### PR DESCRIPTION
Adds CommonSparseMatrix to the tested matrices. Solver Tests for CommonSparseMatrix are disabled by now as there is no specialization of the Solver class. Also fixes #7. This PR is based on #9 which thus should be merged first. 