### PR TITLE
Another attempt on thread-safe containers

### DIFF
--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -285,6 +285,16 @@ protected:
   }
 
 public:
+  inline ScalarType& operator[](const size_t ii)
+  {
+    return get_entry_ref(ii);
+  }
+
+  inline const ScalarType& operator[](const size_t ii) const
+  {
+    return get_entry_ref(ii);
+  }
+
   /// \}
   /// \name These methods override default implementations from VectorInterface.
   /// \{

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -346,6 +346,12 @@ public:
     backend_ref -= other.backend();
   } // ... isub(...)
 
+  // without these using declarations, the free operator+/* function in xt/common/vector.hh is chosen instead of the
+  // member function
+  using VectorInterfaceType::operator+;
+  using VectorInterfaceType::operator-;
+  using VectorInterfaceType::operator*;
+
 protected:
   /**
    * \see ContainerInterface

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -821,13 +821,10 @@ public:
 
   //! Matrix-Vector multiplication for dune-xt-la vectors
   template <class XX, class YY>
-  inline std::enable_if_t<std::is_base_of<VectorInterface<typename XX::Traits, ScalarType>, XX>::value
-                              && std::is_base_of<VectorInterface<typename YY::Traits, ScalarType>, YY>::value,
-                          void>
-  mv(const XX& xx, YY& yy) const
+  inline std::enable_if_t<LA::is_vector<XX>::value && LA::is_vector<YY>::value, void> mv(const XX& xx, YY& yy) const
   {
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
-    std::fill(yy.begin(), yy.end(), ScalarType(0));
+    yy.scal(ScalarType(0));
     for (size_t rr = 0; rr < num_rows_; ++rr)
       for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
         yy.add_to_entry(rr, entries_->operator[](kk) * xx.get_entry(column_indices_->operator[](kk)));
@@ -836,10 +833,7 @@ public:
   //! Matrix-Vector multiplication for arbitrary vectors that support operator[]
   //! \note This method may not be thread-safe.
   template <class XX, class YY>
-  inline std::enable_if_t<!std::is_base_of<VectorInterface<typename XX::Traits, ScalarType>, XX>::value
-                              || !std::is_base_of<VectorInterface<typename YY::Traits, ScalarType>, YY>::value,
-                          void>
-  mv(const XX& xx, YY& yy) const
+  inline std::enable_if_t<!LA::is_vector<XX>::value || !LA::is_vector<YY>::value, void> mv(const XX& xx, YY& yy) const
   {
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     std::fill(yy.begin(), yy.end(), ScalarType(0));

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -809,8 +809,27 @@ public:
     return num_cols_;
   }
 
+  //! Matrix-Vector multiplication for dune-xt-la vectors
   template <class XX, class YY>
-  inline void mv(const XX& xx, YY& yy) const
+  inline std::enable_if_t<std::is_base_of<VectorInterface<typename XX::Traits, ScalarType>, XX>::value
+                              && std::is_base_of<VectorInterface<typename YY::Traits, ScalarType>, YY>::value,
+                          void>
+  mv(const XX& xx, YY& yy) const
+  {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    std::fill(yy.begin(), yy.end(), ScalarType(0));
+    for (size_t rr = 0; rr < num_rows_; ++rr)
+      for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
+        yy.add_to_entry(rr, entries_->operator[](kk) * xx.get_entry(column_indices_->operator[](kk)));
+  }
+
+  //! Matrix-Vector multiplication for arbitrary vectors that support operator[]
+  //! \note This method may not be thread-safe.
+  template <class XX, class YY>
+  inline std::enable_if_t<!std::is_base_of<VectorInterface<typename XX::Traits, ScalarType>, XX>::value
+                              || !std::is_base_of<VectorInterface<typename YY::Traits, ScalarType>, YY>::value,
+                          void>
+  mv(const XX& xx, YY& yy) const
   {
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     std::fill(yy.begin(), yy.end(), ScalarType(0));

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -285,16 +285,6 @@ protected:
   }
 
 public:
-  inline ScalarType& operator[](const size_t ii)
-  {
-    return backend()[ii];
-  }
-
-  inline const ScalarType& operator[](const size_t ii) const
-  {
-    return backend()[ii];
-  }
-
   /// \}
   /// \name These methods override default implementations from VectorInterface.
   /// \{

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -163,8 +163,8 @@ public:
 
   ThisType& operator=(const ScalarType& value)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     for (auto& element : *this)
       element = value;
     return *this;
@@ -221,15 +221,15 @@ public:
 
   void scal(const ScalarType& alpha)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (xx.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of x (" << xx.size() << ") does not match the size of this (" << size() << ")!");
@@ -253,16 +253,16 @@ public:
 
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(ii < size());
     backend_ref[ii] += value;
   }
 
   void set_entry(const size_t ii, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(ii < size());
     backend_ref[ii] = value;
   }
@@ -328,8 +328,8 @@ public:
 
   virtual void iadd(const ThisType& other) override final
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -338,8 +338,8 @@ public:
 
   virtual void isub(const ThisType& other) override final
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -352,10 +352,8 @@ protected:
    */
   inline void ensure_uniqueness()
   {
-    if (!backend_.unique()) {
-      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
-    }
   } // ... ensure_uniqueness(...)
 
 private:
@@ -478,15 +476,15 @@ public:
 
   void scal(const ScalarType& alpha)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (!has_equal_shape(xx))
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The shape of xx (" << xx.rows() << "x" << xx.cols() << ") does not match the shape of this ("
@@ -530,8 +528,8 @@ public:
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(ii < rows());
     assert(jj < cols());
     backend_ref[ii][jj] += value;
@@ -539,8 +537,8 @@ public:
 
   void set_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(ii < rows());
     assert(jj < cols());
     backend_ref[ii][jj] = value;
@@ -562,8 +560,8 @@ public:
 
   void clear_row(const size_t ii)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (ii >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the rows of this (" << rows() << ")!");
@@ -572,8 +570,8 @@ public:
 
   void clear_col(const size_t jj)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -583,8 +581,8 @@ public:
 
   void unit_row(const size_t ii)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (ii >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the cols of this (" << cols() << ")!");
@@ -599,8 +597,8 @@ public:
 
   void unit_col(const size_t jj)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -634,10 +632,8 @@ protected:
    */
   inline void ensure_uniqueness()
   {
-    if (!backend_.unique()) {
-      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
-    }
   } // ... ensure_uniqueness(...)
 
 private:
@@ -788,16 +784,16 @@ public:
 
   inline void scal(const ScalarType& alpha)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     std::transform(
         entries_->begin(), entries_->end(), entries_->begin(), std::bind1st(std::multiplies<ScalarType>(), alpha));
   }
 
   inline void axpy(const ScalarType& alpha, const ThisType& xx)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     assert(has_equal_shape(xx));
     const auto& xx_entries = *xx.entries_;
     for (size_t ii = 0; ii < entries_->size(); ++ii)
@@ -835,8 +831,8 @@ public:
 
   inline void add_to_entry(const size_t rr, const size_t cc, const ScalarType& value)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     entries_->operator[](get_entry_index(rr, cc)) += value;
   }
 
@@ -858,15 +854,15 @@ public:
 
   inline void set_entry(const size_t rr, const size_t cc, const ScalarType value)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     entries_->operator[](get_entry_index(rr, cc)) = value;
   }
 
   inline void clear_row(const size_t rr)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     std::fill(entries_->begin() + row_pointers_->operator[](rr),
               entries_->begin() + row_pointers_->operator[](rr + 1),
               ScalarType(0));
@@ -874,8 +870,8 @@ public:
 
   inline void clear_col(const size_t cc)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     for (size_t kk = 0; kk < entries_->size(); ++kk) {
       if (column_indices_->operator[](kk) == cc)
         entries_->operator[](kk) = ScalarType(0);
@@ -947,10 +943,8 @@ private:
 protected:
   inline void ensure_uniqueness()
   {
-    if (!entries_.unique()) {
-      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    if (!entries_.unique())
       entries_ = std::make_shared<EntriesVectorType>(*entries_);
-    }
   } // ... ensure_uniqueness(...)
 
 private:

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -80,6 +80,7 @@ public:
 
   VectorImpType& operator=(const ScalarType& value)
   {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     ensure_uniqueness();
     for (auto& element : *this)
       element = value;

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -223,6 +223,7 @@ protected:
   } // ... ensure_uniqueness(...)
 
 private:
+  friend class VectorInterface<internal::EigenDenseVectorTraits<ScalarType>, ScalarType>;
   friend class EigenBaseVector<internal::EigenDenseVectorTraits<ScalarType>, ScalarType>;
 }; // class EigenDenseVector
 
@@ -347,6 +348,7 @@ protected:
   } // ... ensure_uniqueness(...)
 
 private:
+  friend class VectorInterface<internal::EigenMappedDenseVectorTraits<ScalarType>, ScalarType>;
   friend class EigenBaseVector<internal::EigenMappedDenseVectorTraits<ScalarType>, ScalarType>;
 }; // class EigenMappedDenseVector
 

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -194,6 +194,9 @@ public:
 
   using VectorInterfaceType::add;
   using VectorInterfaceType::sub;
+  using VectorInterfaceType::operator+;
+  using VectorInterfaceType::operator-;
+  using VectorInterfaceType::operator*;
   using BaseType::backend;
 
   /// \name Required by ProvidesDataAccess.
@@ -332,6 +335,9 @@ public:
 
   using VectorInterfaceType::add;
   using VectorInterfaceType::sub;
+  using VectorInterfaceType::operator+;
+  using VectorInterfaceType::operator-;
+  using VectorInterfaceType::operator*;
   using BaseType::backend;
 
 private:

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -218,10 +218,8 @@ private:
 protected:
   inline void ensure_uniqueness()
   {
-    if (!backend_.unique()) {
-      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(this->mutex_);
+    if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*(backend_));
-    }
   } // ... ensure_uniqueness(...)
 
 private:
@@ -342,7 +340,6 @@ protected:
   inline void ensure_uniqueness()
   {
     if (!backend_.unique()) {
-      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(this->mutex_);
       auto new_backend = std::make_shared<BackendType>(new ScalarType[backend_->size()], backend_->size());
       new_backend->operator=(*(backend_));
       backend_ = new_backend;
@@ -496,15 +493,15 @@ public:
 
   void scal(const ScalarType& alpha)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (!has_equal_shape(xx))
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The shape of xx (" << xx.rows() << "x" << xx.cols() << ") does not match the shape of this ("
@@ -543,8 +540,8 @@ public:
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(ii < rows());
     assert(jj < cols());
     backend_ref(ii, jj) += value;
@@ -552,8 +549,8 @@ public:
 
   void set_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(ii < rows());
     assert(jj < cols());
     backend_ref(ii, jj) = value;
@@ -575,8 +572,8 @@ public:
 
   void clear_row(const size_t ii)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (ii >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the rows of this (" << rows() << ")!");
@@ -586,8 +583,8 @@ public:
 
   void clear_col(const size_t jj)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -597,8 +594,8 @@ public:
 
   void unit_row(const size_t ii)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (ii >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the cols of this (" << cols() << ")!");
@@ -612,8 +609,8 @@ public:
 
   void unit_col(const size_t jj)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -645,10 +642,8 @@ public:
 protected:
   inline void ensure_uniqueness()
   {
-    if (!backend_.unique()) {
-      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
-    }
   } // ... ensure_uniqueness(...)
 
 private:

--- a/dune/xt/la/container/eigen/sparse.hh
+++ b/dune/xt/la/container/eigen/sparse.hh
@@ -220,15 +220,15 @@ public:
 
   void scal(const ScalarType& alpha)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (!has_equal_shape(xx))
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The shape of xx (" << xx.rows() << "x" << xx.cols() << ") does not match the shape of this ("
@@ -267,8 +267,8 @@ public:
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(these_are_valid_indices(ii, jj));
     backend_ref.coeffRef(internal::boost_numeric_cast<EIGEN_size_t>(ii),
                          internal::boost_numeric_cast<EIGEN_size_t>(jj)) += value;
@@ -276,8 +276,8 @@ public:
 
   void set_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(these_are_valid_indices(ii, jj));
     backend_ref.coeffRef(internal::boost_numeric_cast<EIGEN_size_t>(ii),
                          internal::boost_numeric_cast<EIGEN_size_t>(jj)) = value;
@@ -303,8 +303,8 @@ public:
 
   void clear_row(const size_t ii)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (ii >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the rows of this (" << rows() << ")!");
@@ -313,8 +313,8 @@ public:
 
   void clear_col(const size_t jj)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -335,8 +335,8 @@ public:
 
   void unit_row(const size_t ii)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (ii >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the cols of this (" << cols() << ")!");
@@ -353,8 +353,8 @@ public:
 
   void unit_col(const size_t jj)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -458,10 +458,8 @@ private:
 protected:
   inline void ensure_uniqueness()
   {
-    if (!backend_.unique()) {
-      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
-    }
   } // ... ensure_uniqueness(...)
 
 private:

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -347,6 +347,12 @@ public:
 
   /// \}
 
+  // without these using declarations, the free operator+/* function in xt/common/vector.hh is chosen instead of the
+  // member function
+  using VectorInterfaceType::operator+;
+  using VectorInterfaceType::operator-;
+  using VectorInterfaceType::operator*;
+
 protected:
   /**
    * \see ContainerInterface

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -210,15 +210,15 @@ public:
 
   void scal(const ScalarType& alpha)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (xx.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of x (" << xx.size() << ") does not match the size of this (" << size() << ")!");
@@ -244,16 +244,16 @@ public:
 
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(ii < size());
     backend_ref[ii][0] += value;
   }
 
   void set_entry(const size_t ii, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(ii < size());
     backend_ref[ii][0] = value;
   }
@@ -319,8 +319,8 @@ public:
 
   virtual void iadd(const ThisType& other) override final
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -329,8 +329,8 @@ public:
 
   virtual void isub(const ThisType& other) override final
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -345,10 +345,8 @@ protected:
    */
   inline void ensure_uniqueness()
   {
-    if (!backend_.unique()) {
-      std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    if (!backend_.unique())
       backend_ = std::make_shared<BackendType>(*backend_);
-    }
   } // ... ensure_uniqueness(...)
 
 private:
@@ -478,15 +476,15 @@ public:
 
   void scal(const ScalarType& alpha)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (!has_equal_shape(xx))
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The shape of xx (" << xx.rows() << "x" << xx.cols() << ") does not match the shape of this ("
@@ -518,23 +516,23 @@ public:
 
   inline void mv(const IstlDenseVector<ScalarType>& xx, IstlDenseVector<ScalarType>& yy) const
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     backend_ref.mv(xx.backend(), yy.backend());
   }
 
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(these_are_valid_indices(ii, jj));
     backend_ref[ii][jj][0][0] += value;
   }
 
   void set_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     assert(these_are_valid_indices(ii, jj));
     backend_ref[ii][jj][0][0] = value;
   }
@@ -560,8 +558,8 @@ public:
 
   void clear_row(const size_t ii)
   {
-    auto& backend_ref = backend();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    auto& backend_ref = backend();
     if (ii >= rows())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the rows of this (" << rows() << ")!");
@@ -570,8 +568,8 @@ public:
 
   void clear_col(const size_t jj)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given jj (" << jj << ") is larger than the cols of this (" << cols() << ")!");
@@ -585,8 +583,8 @@ public:
 
   void unit_row(const size_t ii)
   {
-    ensure_uniqueness();
     std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
     if (ii >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Given ii (" << ii << ") is larger than the cols of this (" << cols() << ")!");
@@ -602,6 +600,7 @@ public:
 
   void unit_col(const size_t jj)
   {
+    mutex_.lock();
     ensure_uniqueness();
     if (jj >= cols())
       DUNE_THROW(Common::Exceptions::index_out_of_range,
@@ -612,7 +611,6 @@ public:
     if (!backend_->exists(jj, jj))
       DUNE_THROW(Common::Exceptions::index_out_of_range,
                  "Diagonal entry (" << jj << ", " << jj << ") is not contained in the sparsity pattern!");
-    mutex_.lock();
     for (size_t ii = 0; (ii < rows()) && (ii != jj); ++ii) {
       auto& row = backend_->operator[](ii);
       const auto search_result = row.find(jj);

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -159,6 +159,14 @@ public:
     return *this;
   }
 
+  ThisType& operator=(const ScalarType& val)
+  {
+    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
+    ensure_uniqueness();
+    std::fill(this->begin(), this->end(), val);
+    return *this;
+  }
+
   /**
    *  \note Does a deep copy.
    */

--- a/dune/xt/la/container/matrix-interface.hh
+++ b/dune/xt/la/container/matrix-interface.hh
@@ -229,14 +229,14 @@ public:
       const auto other_cols = std::set<size_t>(other_pattern.inner(ii).begin(), other_pattern.inner(ii).end());
       for (const auto& jj : my_cols)
         if (other_cols.count(jj) == 0) {
-          if (Common::FloatCmp::ne(get_entry(ii, jj), 0., epsilon))
+          if (Common::FloatCmp::ne(get_entry(ii, jj), ScalarType(0.), epsilon))
             return false;
         } else {
           if (Common::FloatCmp::ne(get_entry(ii, jj), other.get_entry(ii, jj), epsilon))
             return false;
         }
       for (const auto& jj : other_cols)
-        if (my_cols.count(jj) == 0 && Common::FloatCmp::ne(other.get_entry(ii, jj), 0., epsilon))
+        if (my_cols.count(jj) == 0 && Common::FloatCmp::ne(other.get_entry(ii, jj), ScalarType(0.), epsilon))
           return false;
     }
     return true;

--- a/dune/xt/la/container/vector-interface-internal.hh
+++ b/dune/xt/la/container/vector-interface-internal.hh
@@ -80,7 +80,7 @@ public:
   {
     if (end_)
       DUNE_THROW(Common::Exceptions::you_are_using_this_wrong, "This is the end!");
-    return const_holder_->element[position_];
+    return const_holder_->element.get_entry_ref(position_);
   }
 
 private:
@@ -126,7 +126,7 @@ public:
   {
     if (this->end_)
       DUNE_THROW(Common::Exceptions::you_are_using_this_wrong, "This is the end!");
-    return holder_->element[this->position_];
+    return holder_->element.get_entry_ref(this->position_);
   } // ... operator*()
 
 private:

--- a/dune/xt/la/container/vector-interface.hh
+++ b/dune/xt/la/container/vector-interface.hh
@@ -488,6 +488,7 @@ public:
 
   iterator begin()
   {
+    this->as_imp().ensure_uniqueness();
     return iterator(*this);
   }
 

--- a/dune/xt/la/container/vector-interface.hh
+++ b/dune/xt/la/container/vector-interface.hh
@@ -137,6 +137,26 @@ public:
   } // ... valid()
 
   /**
+   * \brief Get writable reference to the iith entry.
+   * \note \attention The returned reference may be invalid once (any entry of) the vector is changed!
+   */
+  inline ScalarType& operator[](const size_t ii)
+  {
+    CHECK_CRTP(this->as_imp()[ii]);
+    return this->as_imp()[ii];
+  }
+
+  /**
+   * \brief Get read-only reference to the iith entry.
+   * \note \attention The returned reference may be invalid once (any entry of) the vector is changed!
+   */
+  inline const ScalarType& operator[](const size_t ii) const
+  {
+    CHECK_CRTP(this->as_imp()[ii]);
+    return this->as_imp()[ii];
+  }
+
+  /**
    * \brief   The dimension of the vector.
    * \return  The dimension of the vector.
    * \see     size()

--- a/dune/xt/la/container/vector-interface.hh
+++ b/dune/xt/la/container/vector-interface.hh
@@ -51,6 +51,8 @@ public:
 
   typedef internal::VectorInputIterator<Traits, ScalarType> const_iterator;
   typedef internal::VectorOutputIterator<Traits, ScalarType> iterator;
+  friend const_iterator;
+  friend iterator;
 
   static_assert(std::is_same<ScalarType, typename Traits::ScalarType>::value, "");
 
@@ -133,24 +135,6 @@ public:
     }
     return true;
   } // ... valid()
-
-  /**
-   * \brief Get writable reference to the iith entry.
-   */
-  inline ScalarType& operator[](const size_t ii)
-  {
-    CHECK_CRTP(this->as_imp()[ii]);
-    return this->as_imp()[ii];
-  }
-
-  /**
-   * \brief Get read-only reference to the iith entry.
-   */
-  inline const ScalarType& operator[](const size_t ii) const
-  {
-    CHECK_CRTP(this->as_imp()[ii]);
-    return this->as_imp()[ii];
-  }
 
   /**
    * \brief   The dimension of the vector.
@@ -564,6 +548,16 @@ struct VectorAbstractionBase
   {
     return VectorType(sz, val);
   }
+
+  static inline ScalarType get_entry(const VectorType& vector, const size_t ii)
+  {
+    return vector.get_entry(ii);
+  }
+
+  static inline void set_entry(VectorType& vector, const size_t ii, const ScalarType& val)
+  {
+    vector.set_entry(ii, val);
+  }
 }; // struct VectorAbstractionBase
 
 template <class XtLaVectorImp, size_t size>
@@ -599,9 +593,9 @@ std::ostream& operator<<(std::ostream& out, const VectorInterface<T, S>& vector)
   out << "[";
   const size_t sz = vector.size();
   if (sz > 0) {
-    out << vector[0];
+    out << vector.get_entry(0);
     for (size_t ii = 1; ii < sz; ++ii)
-      out << "\n " << vector[ii];
+      out << "\n " << vector.get_entry(ii);
   } else
     out << " ";
   out << "]";

--- a/dune/xt/la/solver/eigen.hh
+++ b/dune/xt/la/solver/eigen.hh
@@ -131,7 +131,7 @@ public:
         }
       }
       for (size_t ii = 0; ii < rhs.size(); ++ii) {
-        const S& val = rhs[ii];
+        const S val = rhs.get_entry(ii);
         if (Common::isnan(val) || Common::isinf(val)) {
           std::stringstream msg;
           msg << "Given rhs contains inf or nan and you requested checking (see options below)!\n"
@@ -185,7 +185,7 @@ public:
     // check
     if (check_for_inf_nan)
       for (size_t ii = 0; ii < solution.size(); ++ii) {
-        const S& val = solution[ii];
+        const S val = solution.get_entry(ii);
         if (Common::isnan(val) || Common::isinf(val)) {
           std::stringstream msg;
           msg << "The computed solution contains inf or nan and you requested checking (see options "
@@ -359,7 +359,7 @@ public:
         }
       }
       for (size_t ii = 0; ii < rhs.size(); ++ii) {
-        const S& val = rhs[ii];
+        const S val = rhs.get_entry(ii);
         if (Common::isnan(val) || Common::isinf(val))
           DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements,
                      "Given rhs contains inf or nan and you requested checking (see options below)!\n"
@@ -561,7 +561,7 @@ public:
     // check
     if (check_for_inf_nan)
       for (size_t ii = 0; ii < solution.size(); ++ii) {
-        const S& val = solution[ii];
+        const S& val = solution.get_entry(ii);
         if (Common::isnan(val) || Common::isinf(val))
           DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements,
                      "The computed solution contains inf or nan and you requested checking (see options "

--- a/dune/xt/la/test/container_matrix.cc
+++ b/dune/xt/la/test/container_matrix.cc
@@ -168,20 +168,20 @@ struct MatrixTest : public ::testing::Test
     for (size_t ii = 0; ii < dim; ++ii)
       vector_countingup.set_entry(ii, ScalarType(ii));
     VectorImp testvector_1(dim); // [0, -2, 2, 1]
-    testvector_1[0] = ScalarType(0);
-    testvector_1[1] = ScalarType(-2);
-    testvector_1[2] = ScalarType(2);
-    testvector_1[3] = ScalarType(1);
+    testvector_1.set_entry(0, ScalarType(0));
+    testvector_1.set_entry(1, ScalarType(-2));
+    testvector_1.set_entry(2, ScalarType(2));
+    testvector_1.set_entry(3, ScalarType(1));
     VectorImp testvector_3(dim); // [-1, 1, -1, 1]
-    testvector_3[0] = ScalarType(-1);
-    testvector_3[1] = ScalarType(1);
-    testvector_3[2] = ScalarType(-1);
-    testvector_3[3] = ScalarType(1);
+    testvector_3.set_entry(0, ScalarType(-1));
+    testvector_3.set_entry(1, ScalarType(1));
+    testvector_3.set_entry(2, ScalarType(-1));
+    testvector_3.set_entry(3, ScalarType(1));
     VectorImp testvector_5(dim); // [1.25, 0, 2.5, -3.5]
-    testvector_5[0] = ScalarType(1.25);
-    testvector_5[1] = ScalarType(0);
-    testvector_5[2] = ScalarType(2.5);
-    testvector_5[3] = ScalarType(-3.5);
+    testvector_5.set_entry(0, ScalarType(1.25));
+    testvector_5.set_entry(1, ScalarType(0));
+    testvector_5.set_entry(2, ScalarType(2.5));
+    testvector_5.set_entry(3, ScalarType(-3.5));
 
     // test mv
     VectorImp result_mv_1(dim);
@@ -191,28 +191,28 @@ struct MatrixTest : public ::testing::Test
     EXPECT_EQ(vector_zeros, result_mv_1);
     EXPECT_EQ(vector_zeros, result_mv_2);
     testmatrix_sparse.mv(testvector_5, result_mv_1);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1.25), result_mv_1[0]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1.25), result_mv_1[1]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1.75), result_mv_1[2]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), result_mv_1[3]);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1.25), result_mv_1.get_entry(0));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1.25), result_mv_1.get_entry(1));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1.75), result_mv_1.get_entry(2));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), result_mv_1.get_entry(3));
     testmatrix_2.mv(testvector_3, result_mv_1);
     result_mv_2 = vector_ones;
     result_mv_2.scal(ScalarType(3));
     EXPECT_EQ(result_mv_1, result_mv_2);
     testmatrix_1.mv(testvector_1, result_mv_1);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(5), result_mv_1[0]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(6), result_mv_1[1]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(7), result_mv_1[2]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(8), result_mv_1[3]);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(5), result_mv_1.get_entry(0));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(6), result_mv_1.get_entry(1));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(7), result_mv_1.get_entry(2));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(8), result_mv_1.get_entry(3));
     testmatrix_sparse.mv(vector_ones, result_mv_1);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0.5), result_mv_1[0]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(2.5), result_mv_1[1]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(-0.5), result_mv_1[2]);
-    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), result_mv_1[3]);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0.5), result_mv_1.get_entry(0));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(2.5), result_mv_1.get_entry(1));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(-0.5), result_mv_1.get_entry(2));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), result_mv_1.get_entry(3));
     VectorImp a = vector_ones;
     matrix_zeros_dense.mv(vector_zeros, a);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), vector_ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), vector_ones.get_entry(ii))) << "check copy-on-write";
     }
 
     // test scal, operator*

--- a/dune/xt/la/test/container_vector.cc
+++ b/dune/xt/la/test/container_vector.cc
@@ -58,8 +58,8 @@ struct VectorTest : public ::testing::Test
       EXPECT_FALSE(
           Common::FloatCmp::ne(d_by_size_and_value.get_entry(ii), D_ScalarType(2) * D_ScalarType(ii) + D_ScalarType(1)))
           << d_by_size_and_value.get_entry(ii);
-      EXPECT_FALSE(Common::FloatCmp::ne(d_by_size_and_value.get_entry(ii), d_by_size_and_value[ii]))
-          << d_by_size_and_value[ii];
+      EXPECT_FALSE(Common::FloatCmp::ne(d_by_size_and_value.get_entry(ii), d_by_size_and_value.get_entry(ii)))
+          << d_by_size_and_value.get_entry(ii);
     }
     size_t d_dim = d_by_size.dim();
     EXPECT_EQ(dim, d_dim);
@@ -137,30 +137,30 @@ struct VectorTest : public ::testing::Test
     for (size_t ii = 0; ii < dim; ++ii)
       countingup.set_entry(ii, ScalarType(ii));
     VectorImp testvector_1(dim); // [0, -2, 2, 1]
-    testvector_1[0] = ScalarType(0);
-    testvector_1[1] = ScalarType(-2);
-    testvector_1[2] = ScalarType(2);
-    testvector_1[3] = ScalarType(1);
+    testvector_1.set_entry(0, ScalarType(0));
+    testvector_1.set_entry(1, ScalarType(-2));
+    testvector_1.set_entry(2, ScalarType(2));
+    testvector_1.set_entry(3, ScalarType(1));
     VectorImp testvector_2(dim); // [0, 2, -2, 1]
-    testvector_2[0] = ScalarType(0);
-    testvector_2[1] = ScalarType(2);
-    testvector_2[2] = ScalarType(-2);
-    testvector_2[3] = ScalarType(1);
+    testvector_2.set_entry(0, ScalarType(0));
+    testvector_2.set_entry(1, ScalarType(2));
+    testvector_2.set_entry(2, ScalarType(-2));
+    testvector_2.set_entry(3, ScalarType(1));
     VectorImp testvector_3(dim); // [-1, 1, -1, 1]
-    testvector_3[0] = ScalarType(-1);
-    testvector_3[1] = ScalarType(1);
-    testvector_3[2] = ScalarType(-1);
-    testvector_3[3] = ScalarType(1);
+    testvector_3.set_entry(0, ScalarType(-1));
+    testvector_3.set_entry(1, ScalarType(1));
+    testvector_3.set_entry(2, ScalarType(-1));
+    testvector_3.set_entry(3, ScalarType(1));
     VectorImp testvector_4(dim); // [0, 3, -2, 0]
-    testvector_4[0] = ScalarType(0);
-    testvector_4[1] = ScalarType(3);
-    testvector_4[2] = ScalarType(-2);
-    testvector_4[3] = ScalarType(0);
+    testvector_4.set_entry(0, ScalarType(0));
+    testvector_4.set_entry(1, ScalarType(3));
+    testvector_4.set_entry(2, ScalarType(-2));
+    testvector_4.set_entry(3, ScalarType(0));
     VectorImp testvector_5(dim); // [1.25, 0, 2.5, -3.5]
-    testvector_5[0] = ScalarType(1.25);
-    testvector_5[1] = ScalarType(0);
-    testvector_5[2] = ScalarType(2.5);
-    testvector_5[3] = ScalarType(-3.5);
+    testvector_5.set_entry(0, ScalarType(1.25));
+    testvector_5.set_entry(1, ScalarType(0));
+    testvector_5.set_entry(2, ScalarType(2.5));
+    testvector_5.set_entry(3, ScalarType(-3.5));
 
     // test amax()
     std::pair<size_t, RealType> amax = zeros.amax();
@@ -321,37 +321,38 @@ struct VectorTest : public ::testing::Test
     scaled_by_operator = testvector_1;
     scaled_by_operator *= ScalarType(2);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(2) * testvector_1[ii], scaled[ii]));
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(2) * testvector_1[ii], scaled_by_operator[ii]));
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(2) * testvector_1.get_entry(ii), scaled.get_entry(ii)));
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(2) * testvector_1.get_entry(ii), scaled_by_operator.get_entry(ii)));
     }
     scaled = testvector_3;
     scaled.scal(ScalarType(-2));
     scaled_by_operator = testvector_3;
     scaled_by_operator *= ScalarType(-2);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(-2) * testvector_3[ii], scaled[ii]));
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(-2) * testvector_3[ii], scaled_by_operator[ii]));
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(-2) * testvector_3.get_entry(ii), scaled.get_entry(ii)));
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(-2) * testvector_3.get_entry(ii), scaled_by_operator.get_entry(ii)));
     }
     scaled = countingup;
     scaled.scal(ScalarType(2.2));
     scaled_by_operator = countingup;
     scaled_by_operator *= ScalarType(2.2);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(2.2) * countingup[ii], scaled[ii]));
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(2.2) * countingup[ii], scaled_by_operator[ii]));
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(2.2) * countingup.get_entry(ii), scaled.get_entry(ii)));
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(2.2) * countingup.get_entry(ii), scaled_by_operator.get_entry(ii)));
     }
     scaled = testvector_5;
     scaled.scal(ScalarType(-3.75));
     scaled_by_operator = testvector_5;
     scaled_by_operator *= ScalarType(-3.75);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(-3.75) * testvector_5[ii], scaled[ii]));
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(-3.75) * testvector_5[ii], scaled_by_operator[ii]));
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(-3.75) * testvector_5.get_entry(ii), scaled.get_entry(ii)));
+      EXPECT_TRUE(
+          Common::FloatCmp::eq(ScalarType(-3.75) * testvector_5.get_entry(ii), scaled_by_operator.get_entry(ii)));
     }
     VectorImp a = ones;
     a.scal(ScalarType(0));
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones.get_entry(ii))) << "check copy-on-write";
     }
 
     // test operator+, operator+=, add, iadd
@@ -364,10 +365,10 @@ struct VectorTest : public ::testing::Test
     VectorImp sum_iadd = zeros;
     sum_iadd.iadd(ones);
     VectorImp sum_correct(dim);
-    sum_correct[0] = ScalarType(1);
-    sum_correct[1] = ScalarType(1);
-    sum_correct[2] = ScalarType(1);
-    sum_correct[3] = ScalarType(1);
+    sum_correct.set_entry(0, ScalarType(1));
+    sum_correct.set_entry(1, ScalarType(1));
+    sum_correct.set_entry(2, ScalarType(1));
+    sum_correct.set_entry(3, ScalarType(1));
     EXPECT_FALSE(sum_operator_iplus != sum_operator_plus || sum_add_1 != sum_add_2 || sum_iadd != sum_add_1
                  || sum_add_1 != sum_operator_plus
                  || sum_add_1 != sum_correct)
@@ -386,10 +387,10 @@ struct VectorTest : public ::testing::Test
     countingup.add(testvector_1, sum_add_2);
     sum_iadd = countingup;
     sum_iadd.iadd(testvector_1);
-    sum_correct[0] = ScalarType(0);
-    sum_correct[1] = ScalarType(-1);
-    sum_correct[2] = ScalarType(4);
-    sum_correct[3] = ScalarType(4);
+    sum_correct.set_entry(0, ScalarType(0));
+    sum_correct.set_entry(1, ScalarType(-1));
+    sum_correct.set_entry(2, ScalarType(4));
+    sum_correct.set_entry(3, ScalarType(4));
     EXPECT_FALSE(sum_operator_iplus != sum_operator_plus || sum_add_1 != sum_add_2 || sum_iadd != sum_add_1
                  || sum_add_1 != sum_operator_plus
                  || sum_add_1 != sum_correct)
@@ -408,10 +409,10 @@ struct VectorTest : public ::testing::Test
     testvector_3.add(testvector_5, sum_add_2);
     sum_iadd = testvector_3;
     sum_iadd.iadd(testvector_5);
-    sum_correct[0] = ScalarType(0.25);
-    sum_correct[1] = ScalarType(1);
-    sum_correct[2] = ScalarType(1.5);
-    sum_correct[3] = ScalarType(-2.5);
+    sum_correct.set_entry(0, ScalarType(0.25));
+    sum_correct.set_entry(1, ScalarType(1));
+    sum_correct.set_entry(2, ScalarType(1.5));
+    sum_correct.set_entry(3, ScalarType(-2.5));
     EXPECT_FALSE(sum_operator_iplus != sum_operator_plus || sum_add_1 != sum_add_2 || sum_iadd != sum_add_1
                  || sum_add_1 != sum_operator_plus
                  || sum_add_1 != sum_correct)
@@ -426,17 +427,17 @@ struct VectorTest : public ::testing::Test
     a = ones;
     a += testvector_3;
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones.get_entry(ii))) << "check copy-on-write";
     }
     a = ones;
     a.iadd(testvector_3);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones.get_entry(ii))) << "check copy-on-write";
     }
     a = ones;
     ones.add(testvector_3, a);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones.get_entry(ii))) << "check copy-on-write";
     }
 
     // test operator-, operator-=, sub, isub
@@ -449,10 +450,10 @@ struct VectorTest : public ::testing::Test
     VectorImp diff_isub = zeros;
     diff_isub.isub(ones);
     VectorImp diff_correct(dim);
-    diff_correct[0] = ScalarType(-1);
-    diff_correct[1] = ScalarType(-1);
-    diff_correct[2] = ScalarType(-1);
-    diff_correct[3] = ScalarType(-1);
+    diff_correct.set_entry(0, ScalarType(-1));
+    diff_correct.set_entry(1, ScalarType(-1));
+    diff_correct.set_entry(2, ScalarType(-1));
+    diff_correct.set_entry(3, ScalarType(-1));
     EXPECT_TRUE(diff_operator_iminus == diff_operator_minus && diff_sub_1 == diff_sub_2 && diff_isub == diff_sub_1
                 && diff_sub_1 == diff_operator_minus
                 && diff_sub_1 == diff_correct)
@@ -471,10 +472,10 @@ struct VectorTest : public ::testing::Test
     testvector_1.sub(testvector_4, diff_sub_2);
     diff_isub = testvector_1;
     diff_isub.isub(testvector_4);
-    diff_correct[0] = ScalarType(-0);
-    diff_correct[1] = ScalarType(-5);
-    diff_correct[2] = ScalarType(4);
-    diff_correct[3] = ScalarType(1);
+    diff_correct.set_entry(0, ScalarType(-0));
+    diff_correct.set_entry(1, ScalarType(-5));
+    diff_correct.set_entry(2, ScalarType(4));
+    diff_correct.set_entry(3, ScalarType(1));
     EXPECT_TRUE(diff_operator_iminus == diff_operator_minus && diff_sub_1 == diff_sub_2 && diff_isub == diff_sub_1
                 && diff_sub_1 == diff_operator_minus
                 && diff_sub_1 == diff_correct)
@@ -493,10 +494,10 @@ struct VectorTest : public ::testing::Test
     testvector_5.sub(testvector_2, diff_sub_2);
     diff_isub = testvector_5;
     diff_isub.isub(testvector_2);
-    diff_correct[0] = ScalarType(1.25);
-    diff_correct[1] = ScalarType(-2);
-    diff_correct[2] = ScalarType(4.5);
-    diff_correct[3] = ScalarType(-4.5);
+    diff_correct.set_entry(0, ScalarType(1.25));
+    diff_correct.set_entry(1, ScalarType(-2));
+    diff_correct.set_entry(2, ScalarType(4.5));
+    diff_correct.set_entry(3, ScalarType(-4.5));
     EXPECT_TRUE(diff_operator_iminus == diff_operator_minus && diff_sub_1 == diff_sub_2 && diff_isub == diff_sub_1
                 && diff_sub_1 == diff_operator_minus
                 && diff_sub_1 == diff_correct)
@@ -511,17 +512,17 @@ struct VectorTest : public ::testing::Test
     a = ones;
     a -= testvector_3;
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones.get_entry(ii))) << "check copy-on-write";
     }
     a = ones;
     a.isub(testvector_3);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones.get_entry(ii))) << "check copy-on-write";
     }
     a = ones;
     ones.sub(testvector_3, a);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones.get_entry(ii))) << "check copy-on-write";
     }
 
     // test operator= for scalars
@@ -558,7 +559,7 @@ struct VectorTest : public ::testing::Test
     a = ones;
     a.axpy(ScalarType(2), testvector_3);
     for (size_t ii = 0; ii < dim; ++ii) {
-      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones[ii])) << "check copy-on-write";
+      EXPECT_TRUE(Common::FloatCmp::eq(ScalarType(1), ones.get_entry(ii))) << "check copy-on-write";
     }
   } // void produces_correct_results() const
 }; // struct VectorTest


### PR DESCRIPTION
Currently, I encountered several segfaults using the ``EigenDenseVector`` in a multi-threaded computation. The reason is that currently, in a lot of methods,  the reference to the backend is obtained before the lock is aquired. This reference may become invalid while the threads waits for getting the lock.

I now moved the ``lock_guard`` before the ``backend()`` call, which should fix this issue. To avoid that a thread tries to lock the same mutex twice, I had to remove the guard from ``ensure_uniqueness``. 

In addition, I removed the ``operator[]``, as the returned reference may be invalid as soon as the vector is modified, which may be immediately in multithreaded computations. As a replacement, I added ``get_entry`` and ``set_entry`` to the `` VectorAbstractions`` and use ``get_entry_ref`` internally.

As I am not sure whether you would like to keep the ``operator[]``, I open this pull request. I we still want to expose it, we should at least document that it is not thread-safe and may become invalid also in single-threaded environments once the vector is modified.