### PR TITLE
Thread-safe operator[], configurable number of mutexes

### DIFF
--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -837,14 +837,14 @@ public:
   } // CommonSparseMatrix(...)
 
   template <int ROWS, int COLS>
-  explicit operator Dune::FieldMatrix<ScalarType, ROWS, COLS>() const
+  explicit operator std::unique_ptr<Dune::FieldMatrix<ScalarType, ROWS, COLS>>() const
   {
     assert(ROWS == num_rows_ && COLS == num_cols_);
-    Dune::FieldMatrix<ScalarType, ROWS, COLS> ret(ScalarType(0));
+    auto ret = XT::Common::make_unique<Dune::FieldMatrix<ScalarType, ROWS, COLS>>(ScalarType(0));
     for (size_t rr = 0; rr < ROWS; ++rr)
       for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
-        ret[rr][column_indices_->operator[](kk)] = entries_->operator[](kk);
-    return ret;
+        (*ret)[rr][column_indices_->operator[](kk)] = entries_->operator[](kk);
+    return std::move(ret);
   }
 
   explicit operator Dune::DynamicMatrix<ScalarType>() const

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -308,10 +308,10 @@ public:
     return get_entry_ref(ii);
   }
 
-  // TODO: Need to ensure uniqueness() and unshareable_ = true also in this method, but that would imply making
-  // ensure_uniqueness const and all members mutable
   inline const ScalarType& operator[](const size_t ii) const
   {
+    ensure_uniqueness();
+    unshareable_ = true;
     return get_entry_ref(ii);
   }
 
@@ -374,7 +374,7 @@ protected:
   /**
    * \see ContainerInterface
    */
-  inline void ensure_uniqueness()
+  inline void ensure_uniqueness() const
   {
     if (!backend_.unique()) {
       assert(!unshareable_);
@@ -615,10 +615,10 @@ public:
     return backend()[ii][jj];
   } // ... get_entry_ref(...)
 
-  // TODO: Need to ensure uniqueness() and unshareable_ = true also in this method, but that would imply making
-  // ensure_uniqueness const and all members mutable
   const ScalarType& get_entry_ref(const size_t ii, const size_t jj) const
   {
+    ensure_uniqueness();
+    unshareable_ = true;
     assert(ii < rows());
     assert(jj < cols());
     return backend()[ii][jj];
@@ -696,7 +696,7 @@ protected:
   /**
    * \see ContainerInterface
    */
-  inline void ensure_uniqueness()
+  inline void ensure_uniqueness() const
   {
     if (!backend_.unique()) {
       assert(!unshareable_);
@@ -709,9 +709,9 @@ protected:
   } // ... ensure_uniqueness(...)
 
 private:
-  std::shared_ptr<BackendType> backend_;
+  mutable std::shared_ptr<BackendType> backend_;
   mutable std::shared_ptr<std::vector<std::mutex>> mutexes_;
-  bool unshareable_;
+  mutable bool unshareable_;
 }; // class CommonDenseMatrix
 
 /**
@@ -954,10 +954,10 @@ public:
     return entries_->operator[](index);
   }
 
-  // TODO: Need to ensure uniqueness() and unshareable_ = true also in this method, but that would imply making
-  // ensure_uniqueness const and entries_, mutexes_ and unshareable_ mutable
   inline const ScalarType& get_entry_ref(const size_t rr, const size_t cc) const
   {
+    ensure_uniqueness();
+    unshareable_ = true;
     const size_t index = get_entry_index(rr, cc, false);
     if (index == size_t(-1))
       DUNE_THROW(Dune::RangeError, "Entry not in matrix pattern!");
@@ -1037,7 +1037,7 @@ public:
   using MatrixInterfaceType::operator-=;
 
 protected:
-  inline void ensure_uniqueness()
+  inline void ensure_uniqueness() const
   {
     if (!entries_.unique()) {
       assert(!unshareable_);
@@ -1065,11 +1065,11 @@ private:
   }
 
   size_t num_rows_, num_cols_;
-  std::shared_ptr<EntriesVectorType> entries_;
+  mutable std::shared_ptr<EntriesVectorType> entries_;
   std::shared_ptr<IndexVectorType> row_pointers_;
   std::shared_ptr<IndexVectorType> column_indices_;
   mutable std::shared_ptr<std::vector<std::mutex>> mutexes_;
-  bool unshareable_;
+  mutable bool unshareable_;
 }; // class CommonSparseMatrix
 
 } // namespace LA

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -393,7 +393,7 @@ private:
 
   mutable std::shared_ptr<BackendType> backend_;
   mutable std::shared_ptr<std::vector<std::mutex>> mutexes_;
-  bool unshareable_;
+  mutable bool unshareable_;
 }; // class CommonDenseVector
 
 

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -832,6 +832,17 @@ public:
   } // CommonSparseMatrix(...)
 
   template <int ROWS, int COLS>
+  explicit operator Dune::FieldMatrix<ScalarType, ROWS, COLS>() const
+  {
+    assert(ROWS == num_rows_ && COLS == num_cols_);
+    Dune::FieldMatrix<ScalarType, ROWS, COLS> ret(ScalarType(0));
+    for (size_t rr = 0; rr < ROWS; ++rr)
+      for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
+        ret[rr][column_indices_->operator[](kk)] = entries_->operator[](kk);
+    return ret;
+  }
+
+  template <int ROWS, int COLS>
   explicit operator std::unique_ptr<Dune::FieldMatrix<ScalarType, ROWS, COLS>>() const
   {
     assert(ROWS == num_rows_ && COLS == num_cols_);

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -836,6 +836,17 @@ public:
     }
   } // CommonSparseMatrix(...)
 
+  template <int ROWS, int COLS>
+  explicit operator Dune::FieldMatrix<ScalarType, ROWS, COLS>() const
+  {
+    assert(ROWS == num_rows_ && COLS == num_cols_);
+    Dune::FieldMatrix<ScalarType, ROWS, COLS> ret(ScalarType(0));
+    for (size_t rr = 0; rr < ROWS; ++rr)
+      for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
+        ret[rr][column_indices_->operator[](kk)] = entries_->operator[](kk);
+    return ret;
+  }
+
   explicit operator Dune::DynamicMatrix<ScalarType>() const
   {
     Dune::DynamicMatrix<ScalarType> ret(rows(), cols(), ScalarType(0));

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -271,7 +271,7 @@ public:
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
     auto& backend_ref = backend();
-    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, ii, size());
+    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, ii);
     assert(ii < size());
     backend_ref[ii] += value;
   }
@@ -308,10 +308,10 @@ public:
     return get_entry_ref(ii);
   }
 
+  // TODO: Need to ensure uniqueness() and unshareable_ = true also in this method, but that would imply making
+  // ensure_uniqueness const and all members mutable
   inline const ScalarType& operator[](const size_t ii) const
   {
-    ensure_uniqueness();
-    unshareable_ = true;
     return get_entry_ref(ii);
   }
 
@@ -585,7 +585,7 @@ public:
   void add_to_entry(const size_t ii, const size_t jj, const ScalarType& value)
   {
     auto& backend_ref = backend();
-    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, ii, rows());
+    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, ii);
     assert(ii < rows());
     assert(jj < cols());
     backend_ref[ii][jj] += value;
@@ -615,10 +615,10 @@ public:
     return backend()[ii][jj];
   } // ... get_entry_ref(...)
 
+  // TODO: Need to ensure uniqueness() and unshareable_ = true also in this method, but that would imply making
+  // ensure_uniqueness const and all members mutable
   const ScalarType& get_entry_ref(const size_t ii, const size_t jj) const
   {
-    ensure_uniqueness();
-    unshareable_ = true;
     assert(ii < rows());
     assert(jj < cols());
     return backend()[ii][jj];
@@ -934,7 +934,7 @@ public:
   inline void add_to_entry(const size_t rr, const size_t cc, const ScalarType& value)
   {
     ensure_uniqueness();
-    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, rr, rows());
+    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, rr);
     entries_->operator[](get_entry_index(rr, cc)) += value;
   }
 
@@ -954,10 +954,10 @@ public:
     return entries_->operator[](index);
   }
 
+  // TODO: Need to ensure uniqueness() and unshareable_ = true also in this method, but that would imply making
+  // ensure_uniqueness const and entries_, mutexes_ and unshareable_ mutable
   inline const ScalarType& get_entry_ref(const size_t rr, const size_t cc) const
   {
-    ensure_uniqueness();
-    unshareable_ = true;
     const size_t index = get_entry_index(rr, cc, false);
     if (index == size_t(-1))
       DUNE_THROW(Dune::RangeError, "Entry not in matrix pattern!");

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -789,13 +789,6 @@ public:
     }
   }
 
-  // TODO: Why is this constructor needed? Remove?
-  explicit CommonSparseMatrix(const int rr, const int cc = 0)
-    : CommonSparseMatrix(size_t(rr), size_t(cc), ScalarType(0))
-  {
-    assert(rr >= 0 && cc >= 0);
-  }
-
   CommonSparseMatrix(const ThisType& other)
     : num_rows_(other.num_rows_)
     , num_cols_(other.num_cols_)
@@ -844,7 +837,7 @@ public:
     for (size_t rr = 0; rr < ROWS; ++rr)
       for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
         (*ret)[rr][column_indices_->operator[](kk)] = entries_->operator[](kk);
-    return std::move(ret);
+    return ret;
   }
 
   explicit operator Dune::DynamicMatrix<ScalarType>() const

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -195,6 +195,7 @@ public:
   ThisType& operator=(const BackendType& other)
   {
     backend_ = std::make_shared<BackendType>(other);
+    unshareable_ = false;
     return *this;
   }
 
@@ -290,12 +291,12 @@ public:
   }
 
 protected:
-  inline ScalarType& get_entry_ref(const size_t ii)
+  inline ScalarType& get_unchecked_ref(const size_t ii)
   {
     return backend_->operator[](ii);
   }
 
-  inline const ScalarType& get_entry_ref(const size_t ii) const
+  inline const ScalarType& get_unchecked_ref(const size_t ii) const
   {
     return backend_->operator[](ii);
   }
@@ -305,14 +306,14 @@ public:
   {
     ensure_uniqueness();
     unshareable_ = true;
-    return get_entry_ref(ii);
+    return get_unchecked_ref(ii);
   }
 
   inline const ScalarType& operator[](const size_t ii) const
   {
     ensure_uniqueness();
     unshareable_ = true;
-    return get_entry_ref(ii);
+    return get_unchecked_ref(ii);
   }
 
   /// \}
@@ -380,7 +381,7 @@ protected:
       assert(!unshareable_);
       const internal::VectorLockGuard DUNE_UNUSED(guard)(mutexes_);
       if (!backend_.unique()) {
-        backend_ = std::make_shared<BackendType>(*(backend_));
+        backend_ = std::make_shared<BackendType>(*backend_);
         mutexes_ = std::make_shared<std::vector<std::mutex>>(mutexes_->size());
       }
     }
@@ -390,7 +391,7 @@ private:
   friend class VectorInterface<internal::CommonDenseVectorTraits<ScalarType>, ScalarType>;
   friend class CommonDenseMatrix<ScalarType>;
 
-  std::shared_ptr<BackendType> backend_;
+  mutable std::shared_ptr<BackendType> backend_;
   mutable std::shared_ptr<std::vector<std::mutex>> mutexes_;
   bool unshareable_;
 }; // class CommonDenseVector
@@ -502,6 +503,7 @@ public:
   ThisType& operator=(const BackendType& other)
   {
     backend_ = std::make_shared<BackendType>(other);
+    unshareable_ = false;
     return *this;
   }
 

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -836,12 +836,10 @@ public:
     }
   } // CommonSparseMatrix(...)
 
-  template <int ROWS, int COLS>
-  explicit operator Dune::FieldMatrix<ScalarType, ROWS, COLS>() const
+  explicit operator Dune::DynamicMatrix<ScalarType>() const
   {
-    assert(ROWS == num_rows_ && COLS == num_cols_);
-    Dune::FieldMatrix<ScalarType, ROWS, COLS> ret(ScalarType(0));
-    for (size_t rr = 0; rr < ROWS; ++rr)
+    Dune::DynamicMatrix<ScalarType> ret(rows(), cols(), ScalarType(0));
+    for (size_t rr = 0; rr < rows(); ++rr)
       for (size_t kk = row_pointers_->operator[](rr); kk < row_pointers_->operator[](rr + 1); ++kk)
         ret[rr][column_indices_->operator[](kk)] = entries_->operator[](kk);
     return ret;

--- a/dune/xt/la/container/container-interface.hh
+++ b/dune/xt/la/container/container-interface.hh
@@ -90,7 +90,7 @@ static Out boost_numeric_cast(const In& in)
 struct VectorLockGuard
 {
   VectorLockGuard(std::shared_ptr<std::vector<std::mutex>>& mutexes)
-    : mutexes_(mutexes)
+    : mutexes_(mutexes ? mutexes.get() : nullptr)
   {
     if (mutexes_)
       boost::lock(mutexes_->begin(), mutexes_->end());
@@ -103,13 +103,13 @@ struct VectorLockGuard
         mutex.unlock();
   }
 
-  std::shared_ptr<std::vector<std::mutex>>& mutexes_;
+  std::vector<std::mutex>* mutexes_;
 }; // VectorLockGuard
 
 struct LockGuard
 {
   LockGuard(std::shared_ptr<std::vector<std::mutex>>& mutexes, const size_t& ii, const size_t& size)
-    : mutexes_(mutexes)
+    : mutexes_(mutexes ? mutexes.get() : nullptr)
     , index_(ii / size_t(std::ceil(double(size) / mutexes_->size()) + 0.5))
   {
     if (mutexes_)
@@ -122,7 +122,7 @@ struct LockGuard
       mutexes_->operator[](index_).unlock();
   }
 
-  std::shared_ptr<std::vector<std::mutex>>& mutexes_;
+  std::vector<std::mutex>* mutexes_;
   const size_t index_;
 }; // LockGuard
 

--- a/dune/xt/la/container/container-interface.hh
+++ b/dune/xt/la/container/container-interface.hh
@@ -108,9 +108,9 @@ struct VectorLockGuard
 
 struct LockGuard
 {
-  LockGuard(std::shared_ptr<std::vector<std::mutex>>& mutexes, const size_t& ii, const size_t& size)
+  LockGuard(std::shared_ptr<std::vector<std::mutex>>& mutexes, const size_t& ii)
     : mutexes_(mutexes ? mutexes.get() : nullptr)
-    , index_(ii / size_t(std::ceil(double(size) / mutexes_->size()) + 0.5))
+    , index_(ii % mutexes_->size())
   {
     if (mutexes_)
       mutexes_->operator[](index_).lock();

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -175,12 +175,12 @@ public:
   }
 
 protected:
-  inline ScalarType& get_entry_ref(const size_t ii)
+  inline ScalarType& get_unchecked_ref(const size_t ii)
   {
     return (*backend_)[ii];
   }
 
-  inline const ScalarType& get_entry_ref(const size_t ii) const
+  inline const ScalarType& get_unchecked_ref(const size_t ii) const
   {
     return (*backend_)[ii];
   }

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -195,6 +195,8 @@ public:
 
   inline const ScalarType& operator[](const size_t ii) const
   {
+    ensure_uniqueness();
+    unshareable_ = true;
     return backend()[ii];
   }
 

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -27,8 +27,8 @@
 #include <dune/common/ftraits.hh>
 #include <dune/common/unused.hh>
 
-#include <dune/xt/common/exceptions.hh>
 #include <dune/xt/common/crtp.hh>
+#include <dune/xt/common/exceptions.hh>
 #include <dune/xt/common/float_cmp.hh>
 
 #include "dune/xt/la/container/interfaces.hh"
@@ -64,23 +64,34 @@ public:
   typedef typename Traits::BackendType BackendType;
   typedef typename Traits::derived_type VectorImpType;
 
-  EigenBaseVector() = default;
-
-  EigenBaseVector(EigenBaseVector&& source)
-    : backend_(std::move(source.backend_))
+  EigenBaseVector(size_t num_mutexes = 1)
+    : mutexes_(num_mutexes > 0 ? std::make_shared<std::vector<std::mutex>>(num_mutexes) : nullptr)
+    , unshareable_(false)
   {
   }
 
+  EigenBaseVector(const EigenBaseVector& other)
+    : backend_(other.unshareable_ ? std::make_shared<BackendType>(*other.backend_) : other.backend_)
+    , mutexes_(other.unshareable_ ? std::make_shared<std::vector<std::mutex>>(other.mutexes_->size()) : other.mutexes_)
+    , unshareable_(false)
+  {
+  }
+
+  EigenBaseVector(EigenBaseVector&& source) = default;
+
   VectorImpType& operator=(const ThisType& other)
   {
-    if (this != &other)
-      backend_ = other.backend_;
+    if (this != &other) {
+      backend_ = other.unshareable_ ? std::make_shared<BackendType>(*other.backend_) : other.backend_;
+      mutexes_ =
+          other.unshareable_ ? std::make_shared<std::vector<std::mutex>>(other.mutexes_->size()) : other.mutexes_;
+      unshareable_ = false;
+    }
     return this->as_imp();
   } // ... operator=(...)
 
   VectorImpType& operator=(const ScalarType& value)
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     ensure_uniqueness();
     for (auto& element : *this)
       element = value;
@@ -107,22 +118,21 @@ public:
 
   VectorImpType copy() const
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return VectorImpType(*backend_);
   }
 
   void scal(const ScalarType& alpha)
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     auto& backend_ref = backend();
+    const internal::VectorLockGuard DUNE_UNUSED(guard)(mutexes_);
     backend_ref *= alpha;
   }
 
   template <class T>
   void axpy(const ScalarType& alpha, const EigenBaseVector<T, ScalarType>& xx)
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     auto& backend_ref = backend();
+    const internal::VectorLockGuard DUNE_UNUSED(guard)(mutexes_);
     if (xx.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of xx (" << xx.size() << ") does not match the size of this (" << size() << ")!");
@@ -145,15 +155,14 @@ public:
 
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     auto& backend_ref = backend();
+    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, ii, size());
     assert(ii < size());
     backend_ref(ii) += value;
   }
 
   void set_entry(const size_t ii, const ScalarType& value)
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     auto& backend_ref = backend();
     assert(ii < size());
     backend_ref(ii) = value;
@@ -179,6 +188,8 @@ protected:
 public:
   inline ScalarType& operator[](const size_t ii)
   {
+    ensure_uniqueness();
+    unshareable_ = true;
     return backend()[ii];
   }
 
@@ -194,7 +205,6 @@ public:
 
   virtual std::pair<size_t, RealType> amax() const override final
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     auto result = std::make_pair(size_t(0), RealType(0));
     size_t min_index = 0;
     size_t max_index = 0;
@@ -213,7 +223,6 @@ public:
   template <class T>
   ScalarType dot(const EigenBaseVector<T, ScalarType>& other) const
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -227,27 +236,24 @@ public:
 
   virtual RealType l1_norm() const override final
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return backend().template lpNorm<1>();
   }
 
   virtual RealType l2_norm() const override final
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return backend().template lpNorm<2>();
   }
 
   virtual RealType sup_norm() const override final
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     return backend().template lpNorm<::Eigen::Infinity>();
   }
 
   template <class T>
   void iadd(const EigenBaseVector<T, ScalarType>& other)
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     auto& backend_ref = backend();
+    const internal::VectorLockGuard DUNE_UNUSED(guard)(mutexes_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -262,8 +268,8 @@ public:
   template <class T>
   void isub(const EigenBaseVector<T, ScalarType>& other)
   {
-    std::lock_guard<std::mutex> DUNE_UNUSED(lock)(mutex_);
     auto& backend_ref = backend();
+    const internal::VectorLockGuard DUNE_UNUSED(guard)(mutexes_);
     if (other.size() != size())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
@@ -302,7 +308,8 @@ private:
 
 protected:
   std::shared_ptr<BackendType> backend_;
-  mutable std::mutex mutex_;
+  mutable std::shared_ptr<std::vector<std::mutex>> mutexes_;
+  bool unshareable_;
 }; // class EigenBaseVector
 
 #else // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -193,10 +193,10 @@ public:
     return backend()[ii];
   }
 
-  // TODO: Need to ensure uniqueness() and unshareable_ = true also in this method, but that would imply making
-  // ensure_uniqueness const and all members mutable
   inline const ScalarType& operator[](const size_t ii) const
   {
+    ensure_uniqueness();
+    unshareable_ = true;
     return backend()[ii];
   }
 
@@ -292,7 +292,7 @@ protected:
   /**
    * \see ContainerInterface
    */
-  void ensure_uniqueness()
+  void ensure_uniqueness() const
   {
     CHECK_AND_CALL_CRTP(VectorInterfaceType::as_imp().ensure_uniqueness());
     VectorInterfaceType::as_imp().ensure_uniqueness();
@@ -309,9 +309,9 @@ private:
   friend class EigenRowMajorSparseMatrix<ScalarType>;
 
 protected:
-  std::shared_ptr<BackendType> backend_;
-  std::shared_ptr<std::vector<std::mutex>> mutexes_;
-  bool unshareable_;
+  mutable std::shared_ptr<BackendType> backend_;
+  mutable std::shared_ptr<std::vector<std::mutex>> mutexes_;
+  mutable bool unshareable_;
 }; // class EigenBaseVector
 
 #else // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -156,7 +156,7 @@ public:
   void add_to_entry(const size_t ii, const ScalarType& value)
   {
     auto& backend_ref = backend();
-    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, ii, size());
+    internal::LockGuard DUNE_UNUSED(lock)(mutexes_, ii);
     assert(ii < size());
     backend_ref(ii) += value;
   }
@@ -193,10 +193,10 @@ public:
     return backend()[ii];
   }
 
+  // TODO: Need to ensure uniqueness() and unshareable_ = true also in this method, but that would imply making
+  // ensure_uniqueness const and all members mutable
   inline const ScalarType& operator[](const size_t ii) const
   {
-    ensure_uniqueness();
-    unshareable_ = true;
     return backend()[ii];
   }
 
@@ -310,7 +310,7 @@ private:
 
 protected:
   std::shared_ptr<BackendType> backend_;
-  mutable std::shared_ptr<std::vector<std::mutex>> mutexes_;
+  std::shared_ptr<std::vector<std::mutex>> mutexes_;
   bool unshareable_;
 }; // class EigenBaseVector
 

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -231,7 +231,7 @@ protected:
       assert(!unshareable_);
       const internal::VectorLockGuard DUNE_UNUSED(guard)(mutexes_);
       if (!backend_.unique()) {
-        backend_ = std::make_shared<BackendType>(*(backend_));
+        backend_ = std::make_shared<BackendType>(*backend_);
         mutexes_ = std::make_shared<std::vector<std::mutex>>(mutexes_->size());
       }
     }

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -191,7 +191,6 @@ public:
   ThisType& operator=(const BackendType& other)
   {
     backend_ = std::make_shared<BackendType>(other);
-    mutexes_ = std::make_shared<std::vector<std::mutex>>(mutexes_->size());
     unshareable_ = false;
     return *this;
   } // ... operator=(...)
@@ -337,6 +336,7 @@ public:
   {
     backend_ = std::make_shared<BackendType>(new ScalarType[other.size()], other.size());
     backend_->operator=(other);
+    unshareable_ = false;
     return *this;
   }
 
@@ -499,6 +499,7 @@ public:
   ThisType& operator=(const BackendType& other)
   {
     backend_ = std::make_shared<BackendType>(other);
+    unshareable_ = false;
     return *this;
   }
 

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -174,6 +174,7 @@ public:
           other.unshareable_ ? std::make_shared<std::vector<std::mutex>>(other.mutexes_->size()) : other.mutexes_;
       unshareable_ = false;
     }
+    return *this;
   }
 
   ThisType& operator=(const ScalarType& val)
@@ -531,14 +532,12 @@ public:
     auto& backend_ref = backend();
     const internal::VectorLockGuard DUNE_UNUSED(guard)(mutexes_);
     backend_ref *= alpha;
-    backend_ref *= alpha;
   }
 
   void axpy(const ScalarType& alpha, const ThisType& xx)
   {
     auto& backend_ref = backend();
     const internal::VectorLockGuard DUNE_UNUSED(guard)(mutexes_);
-    backend_ref *= alpha;
     if (!has_equal_shape(xx))
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The shape of xx (" << xx.rows() << "x" << xx.cols() << ") does not match the shape of this ("

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -385,7 +385,7 @@ private:
 
   mutable std::shared_ptr<BackendType> backend_;
   mutable std::shared_ptr<std::vector<std::mutex>> mutexes_;
-  bool unshareable_;
+  mutable bool unshareable_;
 }; // class IstlDenseVector
 
 /**

--- a/dune/xt/la/container/matrix-interface.hh
+++ b/dune/xt/la/container/matrix-interface.hh
@@ -478,13 +478,13 @@ struct FieldMatrixToLaDenseMatrix
     return out;
   }
 
-  static FieldMatrixType convert_back(const LaMatrixType& in)
+  static std::unique_ptr<FieldMatrixType> convert_back(const LaMatrixType& in)
   {
-    FieldMatrixType out;
+    auto out = XT::Common::make_unique<FieldMatrixType>();
     for (size_t ii = 0; ii < rows; ++ii)
       for (size_t jj = 0; jj < cols; ++jj)
-        out[ii][jj] = in.get_entry(ii, jj);
-    return out;
+        (*out)[ii][jj] = in.get_entry(ii, jj);
+    return std::move(out);
   }
 };
 

--- a/dune/xt/la/container/matrix-interface.hh
+++ b/dune/xt/la/container/matrix-interface.hh
@@ -94,6 +94,12 @@ public:
     return this->as_imp().get_entry_ref(ii, jj);
   }
 
+  inline const ScalarType& get_entry_ref(const size_t ii, const size_t jj) const
+  {
+    CHECK_CRTP(this->as_imp().get_entry_ref(ii, jj));
+    return this->as_imp().get_entry_ref(ii, jj);
+  }
+
   inline void clear_row(const size_t ii)
   {
     CHECK_AND_CALL_CRTP(this->as_imp().clear_row(ii));

--- a/dune/xt/la/container/matrix-interface.hh
+++ b/dune/xt/la/container/matrix-interface.hh
@@ -24,6 +24,7 @@
 #include <dune/xt/common/exceptions.hh>
 #include <dune/xt/common/float_cmp.hh>
 #include <dune/xt/common/matrix.hh>
+#include <dune/xt/common/memory.hh>
 #include <dune/xt/common/type_traits.hh>
 
 #include "container-interface.hh"

--- a/dune/xt/la/container/vector-interface.hh
+++ b/dune/xt/la/container/vector-interface.hh
@@ -100,19 +100,19 @@ public:
 
 protected:
   /**
-   * The purpose of get_entry_ref is to allow direct access to the underlying data without any checks (regarding cow
+   * The purpose of get_unchecked_ref is to allow direct access to the underlying data without any checks (regarding cow
    * or thread safety). This allows default implementations in the interface with locking prior to for-loops.
    */
-  inline ScalarType& get_entry_ref(const size_t ii)
+  inline ScalarType& get_unchecked_ref(const size_t ii)
   {
-    CHECK_CRTP(this->as_imp().get_entry_ref(ii));
-    return this->as_imp().get_entry_ref(ii);
+    CHECK_CRTP(this->as_imp().get_unchecked_ref(ii));
+    return this->as_imp().get_unchecked_ref(ii);
   }
 
-  inline const ScalarType& get_entry_ref(const size_t ii) const
+  inline const ScalarType& get_unchecked_ref(const size_t ii) const
   {
-    CHECK_CRTP(this->as_imp().get_entry_ref(ii));
-    return this->as_imp().get_entry_ref(ii);
+    CHECK_CRTP(this->as_imp().get_unchecked_ref(ii));
+    return this->as_imp().get_unchecked_ref(ii);
   }
 
 public:
@@ -138,7 +138,6 @@ public:
 
   /**
    * \brief Get writable reference to the iith entry.
-   * \note \attention The returned reference may be invalid once (any entry of) the vector is changed!
    */
   inline ScalarType& operator[](const size_t ii)
   {
@@ -148,12 +147,27 @@ public:
 
   /**
    * \brief Get read-only reference to the iith entry.
-   * \note \attention The returned reference may be invalid once (any entry of) the vector is changed!
    */
   inline const ScalarType& operator[](const size_t ii) const
   {
     CHECK_CRTP(this->as_imp()[ii]);
     return this->as_imp()[ii];
+  }
+
+  /**
+  * \brief Get writable reference to the iith entry.
+  */
+  inline ScalarType& get_entry_ref(const size_t ii)
+  {
+    return this->operator[](ii);
+  }
+
+  /**
+   * \brief Get read-only reference to the iith entry.
+   */
+  inline const ScalarType& get_entry_ref(const size_t ii) const
+  {
+    return this->operator[](ii);
   }
 
   /**
@@ -185,7 +199,7 @@ public:
     using std::abs;
     auto result = std::make_pair(size_t(0), RealType(0));
     for (size_t ii = 0; ii < size(); ++ii) {
-      const auto value = abs(get_entry_ref(ii));
+      const auto value = abs(get_unchecked_ref(ii));
       if (value > result.second) {
         result.first = ii;
         result.second = value;
@@ -244,7 +258,7 @@ public:
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
     ScalarType result = 0;
     for (size_t ii = 0; ii < size(); ++ii)
-      result += conj(get_entry_ref(ii)) * other.get_entry_ref(ii);
+      result += conj(get_unchecked_ref(ii)) * other.get_unchecked_ref(ii);
     return result;
   } // ... dot(...)
 
@@ -258,7 +272,7 @@ public:
     using std::abs;
     RealType result = 0;
     for (size_t ii = 0; ii < size(); ++ii)
-      result += abs(get_entry_ref(ii));
+      result += abs(get_unchecked_ref(ii));
     return result;
   } // ... l1_norm(...)
 
@@ -313,7 +327,7 @@ public:
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of result (" << result.size() << ") does not match the size of this (" << size() << ")!");
     for (size_t ii = 0; ii < size(); ++ii)
-      result.set_entry(ii, get_entry_ref(ii) + other.get_entry_ref(ii));
+      result.set_entry(ii, get_unchecked_ref(ii) + other.get_unchecked_ref(ii));
   } // ... add(...)
 
   /**
@@ -341,7 +355,7 @@ public:
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
     for (size_t ii = 0; ii < size(); ++ii)
-      set_entry(ii, get_entry_ref(ii) + other.get_entry_ref(ii));
+      add_to_entry(ii, other.get_unchecked_ref(ii));
   } // ... iadd(...)
 
   /**
@@ -359,7 +373,7 @@ public:
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of result (" << result.size() << ") does not match the size of this (" << size() << ")!");
     for (size_t ii = 0; ii < size(); ++ii)
-      result.set_entry(ii, get_entry_ref(ii) - other.get_entry_ref(ii));
+      result.set_entry(ii, get_unchecked_ref(ii) - other.get_unchecked_ref(ii));
   } // ... sub(...)
 
   /**
@@ -386,7 +400,7 @@ public:
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                  "The size of other (" << other.size() << ") does not match the size of this (" << size() << ")!");
     for (size_t ii = 0; ii < size(); ++ii)
-      set_entry(ii, get_entry_ref(ii) - other.get_entry_ref(ii));
+      add_to_entry(ii, -other.get_unchecked_ref(ii));
   } // ... isub(...)
 
   using BaseType::operator*;

--- a/dune/xt/la/test/container_matrix.cc
+++ b/dune/xt/la/test/container_matrix.cc
@@ -183,6 +183,27 @@ struct MatrixTest : public ::testing::Test
     testvector_5.set_entry(2, ScalarType(2.5));
     testvector_5.set_entry(3, ScalarType(-3.5));
 
+    // test get_entry()
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), testmatrix_1.get_entry(0, 0));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(3), testmatrix_1.get_entry(1, 2));
+
+    // test get_entry_ref
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), testmatrix_1.get_entry_ref(0, 0));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(3), testmatrix_1.get_entry_ref(1, 2));
+    MatrixImp testmatrix_1_copy = testmatrix_1;
+    const ScalarType& entry00 = testmatrix_1_copy.get_entry_ref(0, 0);
+    ScalarType& entry12 = testmatrix_1_copy.get_entry_ref(1, 2);
+    testmatrix_1.scal(ScalarType(2));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), entry00);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(3), entry12);
+    testmatrix_1.scal(ScalarType(0.5));
+    testmatrix_1_copy.scal(ScalarType(3));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), entry00);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(9), entry12);
+    entry12 = ScalarType(42);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(42), testmatrix_1_copy.get_entry(1, 2));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(3), testmatrix_1.get_entry(1, 2));
+
     // test mv
     VectorImp result_mv_1(dim);
     matrix_zeros_dense.mv(vector_zeros, result_mv_1);

--- a/dune/xt/la/test/container_vector.cc
+++ b/dune/xt/la/test/container_vector.cc
@@ -162,6 +162,40 @@ struct VectorTest : public ::testing::Test
     testvector_5.set_entry(2, ScalarType(2.5));
     testvector_5.set_entry(3, ScalarType(-3.5));
 
+    // test get_entry()
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), testvector_1.get_entry(0));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(-2), testvector_1.get_entry(1));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(2), testvector_1.get_entry(2));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1), testvector_1.get_entry(3));
+
+    // test operator[] and get_entry_ref
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), testvector_1[0]);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(-2), testvector_1[1]);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(2), testvector_1.get_entry_ref(2));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1), testvector_1.get_entry_ref(3));
+    VectorImp testvector_1_copy = testvector_1;
+    const ScalarType& entry0 = testvector_1_copy[0];
+    ScalarType& entry3 = testvector_1_copy[3];
+    testvector_1.scal(ScalarType(2));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), entry0);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1), entry3);
+    testvector_1.scal(ScalarType(0.5));
+    testvector_1_copy.scal(ScalarType(3));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(0), entry0);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(3), entry3);
+    entry3 = ScalarType(42);
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(42), testvector_1_copy.get_entry(3));
+    EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(1), testvector_1.get_entry(3));
+
+    // test iterators
+    const auto it_end = countingup.end();
+    size_t count = 0;
+    for (auto it = countingup.begin(); it != it_end; ++it)
+      EXPECT_DOUBLE_OR_COMPLEX_EQ(*it, ScalarType(count++));
+    count = 0;
+    for (const auto& entry : countingup)
+      EXPECT_DOUBLE_OR_COMPLEX_EQ(entry, ScalarType(count++));
+
     // test amax()
     std::pair<size_t, RealType> amax = zeros.amax();
     EXPECT_EQ(0, amax.first);

--- a/dune/xt/la/test/container_vector.cc
+++ b/dune/xt/la/test/container_vector.cc
@@ -191,10 +191,10 @@ struct VectorTest : public ::testing::Test
     const auto it_end = countingup.end();
     size_t count = 0;
     for (auto it = countingup.begin(); it != it_end; ++it)
-      EXPECT_DOUBLE_OR_COMPLEX_EQ(*it, ScalarType(count++));
+      EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(count++), *it);
     count = 0;
     for (const auto& entry : countingup)
-      EXPECT_DOUBLE_OR_COMPLEX_EQ(entry, ScalarType(count++));
+      EXPECT_DOUBLE_OR_COMPLEX_EQ(RealType(count++), entry);
 
     // test amax()
     std::pair<size_t, RealType> amax = zeros.amax();


### PR DESCRIPTION
A first proposal to fix #18 and #20. I only adapted the Eigen vectors for now, but the same should work for the other vectors and matrices. 
I am following the lines of http://www.gotw.ca/gotw/045.htm, so I removed the locks in all methods that yield undefined behavior when called from two threads at the same time anyway (e.g. when calling ``vector.set_entry(0, 0.)`` from one thread and ``vector.set_entry(0, 1.)`` from another thread at the same time, we can't tell if the result is 0 or 1 even if ``set_entry`` is thread-safe).
To make it possible to call ``set_entry`` and ``add_to_entry`` for different entries in parallel, the vectors now take a ``num_mutexes`` argument (defaulted to 1) that determines the number of mutexes used. If ``num_mutexes == 10`` and ``vector.size() == 100``, entries 0-9 will be protected by the first mutex, entries 10-19 by the second and so on. This greatly reduced locking for me when using the L2 projection in dune-gdt, which calls ``set_entry`` on the vector of the discrete function repeatedly on each entitity.
Having several mutexes implies that we need to lock all of them when doing global operations like ``axpy`` which might worsen performance when doing a lot of global operations, so I kept the number of mutexes configurable.
As for ``operator[]``, I added an ``unshareable_`` flag that is set when the non-const ``operator[]`` is called. If that flag is set, we will always do a deep copy instead of copy-on-write for that vector.